### PR TITLE
Fixes to get names working

### DIFF
--- a/libraries/Bluefruit52Lib/examples/Central/central_bleuart/central_bleuart.ino
+++ b/libraries/Bluefruit52Lib/examples/Central/central_bleuart/central_bleuart.ino
@@ -21,16 +21,16 @@
 BLEClientDis  clientDis;
 BLEClientUart clientUart;
 
-void setup() 
+void setup()
 {
   Serial.begin(115200);
 
   Serial.println("Bluefruit52 Central BLEUART Example");
   Serial.println("-----------------------------------");
-  
+
   // up to 1 peripheral conn and 1 central conn
+  Bluefruit.setName("Bluefruit52"); // set name first
   Bluefruit.begin(true, true);
-  Bluefruit.setName("Bluefruit52");
 
   // Configure DIS client
   clientDis.begin();
@@ -39,7 +39,7 @@ void setup()
   clientUart.begin();
   clientUart.setRxCallback(uart_rx_callback);
 
-  // Increase BLink rate to different from PrPh advertising mode 
+  // Increase BLink rate to different from PrPh advertising mode
   Bluefruit.setConnLedInterval(250);
 
   // Callbacks for Central
@@ -74,7 +74,7 @@ void connect_callback(uint16_t conn_handle)
   {
     Serial.println("Found it");
     char buffer[32+1];
-    
+
     // read and print out Manufacturer
     memset(buffer, 0, sizeof(buffer));
     if ( clientDis.getManufacturer(buffer, sizeof(buffer)) )
@@ -92,7 +92,7 @@ void connect_callback(uint16_t conn_handle)
     }
 
     Serial.println();
-  }  
+  }
 
   Serial.print("Discovering BLE Uart Service ... ");
 
@@ -107,14 +107,14 @@ void connect_callback(uint16_t conn_handle)
   }else
   {
     Serial.println("Found NONE");
-  }  
+  }
 }
 
 void disconnect_callback(uint16_t conn_handle, uint8_t reason)
 {
   (void) conn_handle;
   (void) reason;
-  
+
   Serial.println("Disconnected");
   Serial.println("Bluefruit will auto start scanning (default)");
 }
@@ -122,7 +122,7 @@ void disconnect_callback(uint16_t conn_handle, uint8_t reason)
 void uart_rx_callback(void)
 {
   Serial.print("[RX]: ");
-  
+
   while ( clientUart.available() )
   {
     Serial.print( (char) clientUart.read() );
@@ -131,7 +131,7 @@ void uart_rx_callback(void)
   Serial.println();
 }
 
-void loop() 
+void loop()
 {
   if ( Bluefruit.Central.connected() )
   {
@@ -143,13 +143,12 @@ void loop()
       if ( Serial.available() )
       {
         delay(2); // delay a bit for all characters to arrive
-        
+
         char str[20+1] = { 0 };
         Serial.readBytes(str, 20);
-        
+
         clientUart.print( str );
       }
     }
   }
 }
-

--- a/libraries/Bluefruit52Lib/examples/Central/central_scan/central_scan.ino
+++ b/libraries/Bluefruit52Lib/examples/Central/central_scan/central_scan.ino
@@ -14,15 +14,15 @@
 
 #include <bluefruit.h>
 
-void setup() 
+void setup()
 {
   Serial.begin(115200);
 
   Serial.println("Bluefruit52 Central Scan Example");
 
   // up to 1 peripheral conn and 1 central conn
+  Bluefruit.setName("Bluefruit52"); // set name first
   Bluefruit.begin(true, true);
-  Bluefruit.setName("Bluefruit52");
 
   // Start Central Scan
   Bluefruit.setConnLedInterval(250);
@@ -37,7 +37,7 @@ void scan_callback(ble_gap_evt_adv_report_t* report)
   Serial.println("Timestamp Addr              Rssi Data");
 
   Serial.printf("%09d ", millis());
-  
+
   Serial.printBuffer(report->peer_addr.addr, 6, ':');
   Serial.print(" ");
 
@@ -56,11 +56,10 @@ void scan_callback(ble_gap_evt_adv_report_t* report)
   Serial.println();
 }
 
-void loop() 
+void loop()
 {
   // Toggle both LEDs every 1 second
   digitalToggle(LED_RED);
 
   delay(1000);
 }
-

--- a/libraries/Bluefruit52Lib/examples/Peripheral/ancs/ancs.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/ancs/ancs.ino
@@ -37,8 +37,8 @@ void setup()
   Serial.println("Go to iOS's Bluetooth settings and connect to Bluefruit52");
   Serial.println("It may appear up as 'Accessory' depending on your OS version.");
 
+  Bluefruit.setName("Bluefruit52"); // set name first
   Bluefruit.begin();
-  Bluefruit.setName("Bluefruit52");
   Bluefruit.setConnectCallback(connect_callback);
   Bluefruit.setDisconnectCallback(disconnect_callback);
 
@@ -83,12 +83,12 @@ void loop()
 void connect_callback(void)
 {
   Serial.println("Connected");
-  
+
   Serial.print("Discovering DIS ... ");
   if ( bleClientDis.discover( Bluefruit.connHandle()) )
   {
     Serial.println("Discovered");
-    
+
     // Read and print Manufacturer string
     memset(buffer, 0, sizeof(buffer));
     if ( bleClientDis.getManufacturer(buffer, sizeof(buffer)) )
@@ -146,12 +146,12 @@ void ancs_notification_callback(AncsNotification_t* notif)
   memset(buffer, 0, sizeof(buffer));
   bleancs.getAttribute(notif->uid, ANCS_ATTR_TITLE, buffer, sizeof(buffer));
   Serial.printf("%-14s | ", buffer);
-  
+
   // Get notification Message
   memset(buffer, 0, sizeof(buffer));
   bleancs.getAttribute(notif->uid, ANCS_ATTR_MESSAGE, buffer, sizeof(buffer));
   Serial.printf("%-15s | ", buffer);
-  
+
   // Get App ID and store in the app_id variable
   char app_id[64] = { 0 };
   memset(buffer, 0, sizeof(buffer));

--- a/libraries/Bluefruit52Lib/examples/Peripheral/ancs_oled/ancs_oled.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/ancs_oled/ancs_oled.ino
@@ -71,7 +71,7 @@ void setup()
   pinMode(BUTTON_C, INPUT_PULLUP);
 
   // init with the I2C addr 0x3C (for the 128x32) and show splashscreen
-  oled.begin(SSD1306_SWITCHCAPVCC, 0x3C); 
+  oled.begin(SSD1306_SWITCHCAPVCC, 0x3C);
   oled.display();
 
   oled.setTextSize(1);// max is 4 line, 21 chars each
@@ -79,8 +79,8 @@ void setup()
 
   Serial.begin(115200);
 
+  Bluefruit.setName("Bluefruit52"); // set name first
   Bluefruit.begin();
-  Bluefruit.setName("Bluefruit52");
   Bluefruit.setConnectCallback(connect_callback);
   Bluefruit.setDisconnectCallback(disconnect_callback);
 
@@ -236,7 +236,7 @@ void connect_callback(void)
   oled.println("Connected.");
   oled.print("Discovering ... ");
   oled.display();
-  
+
   if ( bleancs.discover( Bluefruit.connHandle() ) )
   {
     oled.println("OK");

--- a/libraries/Bluefruit52Lib/examples/Peripheral/beacon/beacon.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/beacon/beacon.ino
@@ -18,27 +18,27 @@
 // the field below to an appropriate value. For a list of valid IDs see:
 // https://www.bluetooth.com/specifications/assigned-numbers/company-identifiers
 // 0x004C is Apple (for example)
-#define MANUFACTURER_ID   0x004C 
+#define MANUFACTURER_ID   0x004C
 
 // AirLocate UUID: E2C56DB5-DFFB-48D2-B060-D0F5A71096E0
-uint8_t beaconUuid[16] = 
-{ 
-  0xE2, 0xC5, 0x6D, 0xB5, 0xDF, 0xFB, 0x48, 0xD2, 
-  0xB0, 0x60, 0xD0, 0xF5, 0xA7, 0x10, 0x96, 0xE0, 
+uint8_t beaconUuid[16] =
+{
+  0xE2, 0xC5, 0x6D, 0xB5, 0xDF, 0xFB, 0x48, 0xD2,
+  0xB0, 0x60, 0xD0, 0xF5, 0xA7, 0x10, 0x96, 0xE0,
 };
 
 // A valid Beacon packet consists of the following information:
 // UUID, Major, Minor, RSSI @ 1M
 BLEBeacon beacon(beaconUuid, 0x0000, 0x0000, -54);
 
-void setup() 
+void setup()
 {
   Serial.begin(115200);
 
   Serial.println("Bluefruit52 Beacon Example");
 
+  Bluefruit.setName("Bluefruit52"); // set name first
   Bluefruit.begin();
-  Bluefruit.setName("Bluefruit52");
 
   // Manufacturer ID is required for Manufacturer Specific Data
   beacon.setManufacturer(MANUFACTURER_ID);
@@ -53,7 +53,7 @@ void setup()
 }
 
 void setupAdv(void)
-{  
+{
   // Set the beacon payload using the BLEBeacon class populated
   // earlier in this example
   Bluefruit.Advertising.setBeacon(beacon);
@@ -65,10 +65,9 @@ void setupAdv(void)
   Bluefruit.ScanResponse.addName();
 }
 
-void loop() 
+void loop()
 {
   // Toggle both LEDs every second
   digitalToggle(LED_RED);
   delay(1000);
 }
-

--- a/libraries/Bluefruit52Lib/examples/Peripheral/blemidi/blemidi.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/blemidi/blemidi.ino
@@ -42,8 +42,8 @@ void setup()
   Serial.begin(115200);
   Serial.println("Adafruit Bluefruit52 MIDI over Bluetooth LE Example");
 
-  Bluefruit.begin();
   Bluefruit.setName("Bluefruit52 MIDI");
+  Bluefruit.begin();
 
   // Setup the on board blue LED to be enabled on CONNECT
   Bluefruit.autoConnLed(true);
@@ -153,4 +153,3 @@ void midiRead()
   // read any new MIDI messages
   MIDI.read();
 }
-

--- a/libraries/Bluefruit52Lib/examples/Peripheral/bleuart/bleuart.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/bleuart/bleuart.ino
@@ -35,8 +35,8 @@ void setup()
   // here in case you want to control this LED manually via PIN 19
   Bluefruit.autoConnLed(true);
 
-  Bluefruit.begin();
   Bluefruit.setName("Bluefruit52");
+  Bluefruit.begin();
   Bluefruit.setConnectCallback(connect_callback);
   Bluefruit.setDisconnectCallback(disconnect_callback);
 
@@ -119,7 +119,7 @@ void disconnect_callback(uint8_t reason)
  * minimal stack size. Therefore it should be as simple as possible. If
  * a periodically heavy task is needed, please use Scheduler.startLoop() to
  * create a dedicated task for it.
- * 
+ *
  * More information http://www.freertos.org/RTOS-software-timer.html
  */
 void blink_timer_callback(TimerHandle_t xTimerID)
@@ -133,25 +133,25 @@ void blink_timer_callback(TimerHandle_t xTimerID)
  * when there are no active threads. E.g when loop() calls delay() and
  * there is no bluetooth or hw event. This is the ideal place to handle
  * background data.
- * 
+ *
  * NOTE: It is recommended to call waitForEvent() to put MCU into low-power mode
  * at the end of this callback. You could also turn off other Peripherals such as
  * Serial/PWM and turn them back on if wanted
- * 
+ *
  * e.g
- * 
+ *
  * void rtos_idle_callback(void)
  * {
  *    Serial.stop(); // will lose data when sleeping
  *    waitForEvent();
- *    Serial.begin(115200); 
+ *    Serial.begin(115200);
  * }
- * 
+ *
  * NOTE2: If rtos_idle_callback() is not defined at all. Bluefruit will force
  * waitForEvent() to save power. If you don't want MCU to sleep at all, define
  * an rtos_idle_callback() with empty body !
- * 
- * WARNING: This function MUST NOT call any blocking FreeRTOS API 
+ *
+ * WARNING: This function MUST NOT call any blocking FreeRTOS API
  * such as delay(), xSemaphoreTake() etc ... for more information
  * http://www.freertos.org/a00016.html
  */
@@ -163,4 +163,3 @@ void rtos_idle_callback(void)
   // Request CPU to enter low-power mode until an event/interrupt occurs
   waitForEvent();
 }
-

--- a/libraries/Bluefruit52Lib/examples/Peripheral/blinky_ota/blinky_ota.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/blinky_ota/blinky_ota.ino
@@ -14,14 +14,14 @@
 
 #include <bluefruit.h>
 
-void setup() 
+void setup()
 {
   Serial.begin(115200);
 
   Serial.println("Bluefruit52 Blinky Example");
 
-  Bluefruit.begin();
   Bluefruit.setName("Bluefruit52");
+  Bluefruit.begin();
 
   // Set up Advertising Packet
   setupAdv();
@@ -31,7 +31,7 @@ void setup()
 }
 
 void setupAdv(void)
-{  
+{
   //Bluefruit.Advertising.addTxPower();
   Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
   Bluefruit.Advertising.addTxPower();
@@ -41,11 +41,10 @@ void setupAdv(void)
   Bluefruit.ScanResponse.addName();
 }
 
-void loop() 
+void loop()
 {
   // Toggle both LEDs every 1 second
   digitalToggle(LED_RED);
 
   delay(1000);
 }
-

--- a/libraries/Bluefruit52Lib/examples/Peripheral/controller/controller.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/controller/controller.ino
@@ -30,8 +30,8 @@ void setup(void)
   Serial.println(F("Adafruit Bluefruit52 Controller App Example"));
   Serial.println(F("-------------------------------------------"));
 
-  Bluefruit.begin();
   Bluefruit.setName("Bluefruit52");
+  Bluefruit.begin();
 
   // Configure and start the BLE Uart service
   bleuart.begin();
@@ -44,14 +44,14 @@ void setup(void)
 
   Serial.println(F("Please use Adafruit Bluefruit LE app to connect in Controller mode"));
   Serial.println(F("Then activate/use the sensors, color picker, game controller, etc!"));
-  Serial.println();  
+  Serial.println();
 }
 
 void setupAdv(void)
 {
   Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
   Bluefruit.Advertising.addTxPower();
-  
+
   // Include the BLE UART (AKA 'NUS') 128-bit UUID
   Bluefruit.Advertising.addService(bleuart);
 

--- a/libraries/Bluefruit52Lib/examples/Peripheral/custom_hrm/custom_hrm.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/custom_hrm/custom_hrm.ino
@@ -42,13 +42,13 @@ void setup()
   Serial.println("Bluefruit52 HRM Example");
   Serial.println("-----------------------");
 
-  // Initialise the Bluefruit module
-  Serial.println("Initialise the Bluefruit nRF52 module");
-  Bluefruit.begin();
-
   // Set the advertised device name (keep it short!)
   Serial.println("Setting Device Name to 'Feather52 HRM'");
   Bluefruit.setName("Feather52 HRM");
+
+  // Initialise the Bluefruit module
+  Serial.println("Initialise the Bluefruit nRF52 module");
+  Bluefruit.begin();
 
   // Set the connect/disconnect callback handlers
   Bluefruit.setConnectCallback(connect_callback);
@@ -189,15 +189,15 @@ void cccd_callback(BLECharacteristic& chr, uint16_t cccd_value)
 void loop()
 {
   digitalToggle(LED_RED);
-  
+
   if ( Bluefruit.connected() ) {
     uint8_t hrmdata[2] = { 0b00000110, bps++ };           // Sensor connected, increment BPS value
-    
+
     // Note: We use .notify instead of .write!
     // If it is connected but CCCD is not enabled
     // The characteristic's value is still updated although notification is not sent
     if ( hrmc.notify(hrmdata, sizeof(hrmdata)) ){
-      Serial.print("Heart Rate Measurement updated to: "); Serial.println(bps); 
+      Serial.print("Heart Rate Measurement updated to: "); Serial.println(bps);
     }else{
       Serial.println("ERROR: Notify not set in the CCCD or not connected!");
     }
@@ -215,7 +215,7 @@ void loop()
  * when there are no active threads. E.g when loop() calls delay() and
  * there is no bluetooth or hw event. This is the ideal place to handle
  * background data.
- * 
+ *
  * NOTE: It is recommended to call waitForEvent() to put MCU into low-power mode
  * at the end of this callback. You could also turn off other Peripherals such as
  * Serial/PWM and turn them back on if wanted
@@ -232,8 +232,8 @@ void loop()
  * NOTE2: If rtos_idle_callback() is not defined at all. Bluefruit will force
  * waitForEvent() to save power. If you don't want MCU to sleep at all, define
  * an rtos_idle_callback() with empty body !
- * 
- * WARNING: This function MUST NOT call any blocking FreeRTOS API 
+ *
+ * WARNING: This function MUST NOT call any blocking FreeRTOS API
  * such as delay(), xSemaphoreTake() etc ... for more information
  * http://www.freertos.org/a00016.html
  */

--- a/libraries/Bluefruit52Lib/examples/Peripheral/hid_camerashutter/hid_camerashutter.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/hid_camerashutter/hid_camerashutter.ino
@@ -41,8 +41,8 @@ void setup()
   Serial.printf("Set pin %d to GND to capture a photo\n", PIN_SHUTTER);
   Serial.println();
 
-  Bluefruit.begin();
   Bluefruit.setName("Bluefruit52");
+  Bluefruit.begin();
 
   // Configure and start DIS (Device Information Service)
   bledis.setManufacturer("Adafruit Industries");

--- a/libraries/Bluefruit52Lib/examples/Peripheral/hid_keyboard/hid_keyboard.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/hid_keyboard/hid_keyboard.ino
@@ -18,7 +18,7 @@ BLEHidAdafruit blehid;
 
 bool hasKeyPressed = false;
 
-void setup() 
+void setup()
 {
   Serial.begin(115200);
 
@@ -31,10 +31,10 @@ void setup()
 
   Serial.println();
   Serial.println("Enter the character(s) to send:");
-  Serial.println();  
+  Serial.println();
 
-  Bluefruit.begin();
   Bluefruit.setName("Bluefruit52");
+  Bluefruit.begin();
 
   // Configure and Start Device Information Service
   bledis.setManufacturer("Adafruit Industries");
@@ -44,7 +44,7 @@ void setup()
   /* Start BLE HID
    * Note: Apple requires BLE device must have min connection interval >= 20m
    * ( The smaller the connection interval the faster we could send data).
-   * However for HID and MIDI device, Apple could accept min connection interval 
+   * However for HID and MIDI device, Apple could accept min connection interval
    * up to 11.25 ms. Therefore BLEHidAdafruit::begin() will try to set the min and max
    * connection interval to 11.25  ms and 15 ms respectively for best performance.
    */
@@ -52,7 +52,7 @@ void setup()
 
   /* Set connection interval (min, max) to your perferred value.
    * Note: It is already set by BLEHidAdafruit::begin() to 11.25ms - 15ms
-   * min = 9*1.25=11.25 ms, max = 12*1.25= 15 ms 
+   * min = 9*1.25=11.25 ms, max = 12*1.25= 15 ms
    */
   /* Bluefruit.setConnInterval(9, 12); */
 
@@ -64,12 +64,12 @@ void setup()
 }
 
 void setupAdv(void)
-{  
+{
   Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
   Bluefruit.Advertising.addTxPower();
 
   Bluefruit.Advertising.addAppearance(BLE_APPEARANCE_HID_KEYBOARD);
-  
+
   // Include BLE HID service
   Bluefruit.Advertising.addService(blehid);
 
@@ -77,7 +77,7 @@ void setupAdv(void)
   Bluefruit.Advertising.addName();
 }
 
-void loop() 
+void loop()
 {
   // Only send KeyRelease if previously pressed to avoid sending
   // multiple keyRelease reports (that consume memory and bandwidth)
@@ -85,27 +85,27 @@ void loop()
   {
     hasKeyPressed = false;
     blehid.keyRelease();
-    
+
     // Delay a bit after a report
     delay(5);
   }
-    
+
   if (Serial.available())
   {
     char ch = (char) Serial.read();
 
     // echo
-    Serial.write(ch); 
+    Serial.write(ch);
 
     blehid.keyPress(ch);
     hasKeyPressed = true;
-    
+
     // Delay a bit after a report
     delay(5);
   }
 
   // Request CPU to enter low-power mode until an event/interrupt occurs
-  waitForEvent();  
+  waitForEvent();
 }
 
 /**
@@ -113,7 +113,7 @@ void loop()
  * when there are no active threads. E.g when loop() calls delay() and
  * there is no bluetooth or hw event. This is the ideal place to handle
  * background data.
- * 
+ *
  * NOTE: It is recommended to call waitForEvent() to put MCU into low-power mode
  * at the end of this callback. You could also turn off other Peripherals such as
  * Serial/PWM and turn them back on if wanted
@@ -130,8 +130,8 @@ void loop()
  * NOTE2: If rtos_idle_callback() is not defined at all. Bluefruit will force
  * waitForEvent() to save power. If you don't want MCU to sleep at all, define
  * an rtos_idle_callback() with empty body !
- * 
- * WARNING: This function MUST NOT call any blocking FreeRTOS API 
+ *
+ * WARNING: This function MUST NOT call any blocking FreeRTOS API
  * such as delay(), xSemaphoreTake() etc ... for more information
  * http://www.freertos.org/a00016.html
  */

--- a/libraries/Bluefruit52Lib/examples/Peripheral/hid_mouse/hid_mouse.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/hid_mouse/hid_mouse.ino
@@ -18,7 +18,7 @@ BLEHidAdafruit blehid;
 
 #define MOVE_STEP    10
 
-void setup() 
+void setup()
 {
   Serial.begin(115200);
 
@@ -33,10 +33,11 @@ void setup()
   Serial.println("- 'LRMBF' to press mouse button(s) (left, right, middle, backward, forward)");
   Serial.println("- 'X'     to release mouse button(s)");
 
-  Bluefruit.begin();
   // HID Device can have a min connection interval of 9*1.25 = 11.25 ms
   Bluefruit.setConnInterval(9, 16); // min = 9*1.25=11.25 ms, max = 16*1.25=20ms
   Bluefruit.setName("Bluefruit52");
+
+  Bluefruit.begin();
 
   // Configure and Start Device Information Service
   bledis.setManufacturer("Adafruit Industries");
@@ -54,12 +55,12 @@ void setup()
 }
 
 void setupAdv(void)
-{  
+{
   Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
   Bluefruit.Advertising.addTxPower();
 
   Bluefruit.Advertising.addAppearance(BLE_APPEARANCE_HID_MOUSE);
-  
+
   // Include BLE HID service
   Bluefruit.Advertising.addService(blehid);
 
@@ -67,18 +68,18 @@ void setupAdv(void)
   Bluefruit.Advertising.addName();
 }
 
-void loop() 
-{    
+void loop()
+{
   if (Serial.available())
   {
     char ch = (char) Serial.read();
 
     // convert to upper case
     ch = (char) toupper(ch);
-    
+
     // echo
     Serial.println(ch);
-  
+
     switch(ch)
     {
       // WASD to move the mouse
@@ -129,4 +130,3 @@ void loop()
     }
   }
 }
-

--- a/libraries/Bluefruit52Lib/examples/Peripheral/neomatrix/neomatrix.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/neomatrix/neomatrix.ino
@@ -17,7 +17,7 @@
  *  - Connect to the board using the Bluefruit Connect LE app
  *  - Send character(s) using BLEUART
  *  - Bluefruit will render the received character(s) on Neopixel FeatherWing
- *  
+ *
  *  Note: due to the font being larger than the 4x8 Neopixel Wing, you can
  *  only see part of the characters in some cases.
  *  Run the sketch with a larger Neopixel Matrix for a complete demo
@@ -59,7 +59,7 @@
 Adafruit_NeoMatrix matrix = Adafruit_NeoMatrix(MATRIX_WIDTH, MATRIX_HEIGHT, PIN,
                                                MATRIX_LAYOUT,
                                                NEO_GRB + NEO_KHZ800);
-                                                 
+
 // BLE Service
 BLEDis  bledis;
 BLEUart bleuart;
@@ -72,7 +72,7 @@ void setup()
 
   Serial.println();
   Serial.println("Please connect using Bluefruit Connect LE application");
-  
+
   // Config Neopixels Matrix
   matrix.begin();
   matrix.setTextWrap(false);
@@ -80,14 +80,14 @@ void setup()
   matrix.setTextColor( matrix.Color(0, 0, 255) ); // Blue for Bluefruit
 
   // Init Bluefruit
-  Bluefruit.begin();
   Bluefruit.setName("Bluefruit52");
   Bluefruit.setConnectCallback(connect_callback);
+  Bluefruit.begin();
 
   // Configure and Start Device Information Service
   bledis.setManufacturer("Adafruit Industries");
   bledis.setModel("Bluefruit Feather52");
-  bledis.begin();  
+  bledis.begin();
 
   // Configure and start BLE UART service
   bleuart.begin();
@@ -100,11 +100,11 @@ void setup()
 }
 
 void setupAdv(void)
-{  
+{
   // Bluefruit.Advertising.addTxPower();
   Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
   Bluefruit.Advertising.addTxPower();
-  
+
   // Include bleuart 128-bit uuid
   Bluefruit.Advertising.addService(bleuart);
 
@@ -134,7 +134,6 @@ void loop()
 
       matrix.show();
       delay(100);
-    }    
-  }  
+    }
+  }
 }
-

--- a/libraries/Bluefruit52Lib/examples/Peripheral/neopixel/neopixel.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/neopixel/neopixel.ino
@@ -51,19 +51,19 @@ void setup()
 
   Serial.println();
   Serial.println("Please connect using the Bluefruit Connect LE application");
-  
+
   // Config Neopixels
   pixels.begin();
 
   // Init Bluefruit
-  Bluefruit.begin();
   Bluefruit.setName("Bluefruit52");
   Bluefruit.setConnectCallback(connect_callback);
+  Bluefruit.begin();
 
   // Configure and Start Device Information Service
   bledis.setManufacturer("Adafruit Industries");
   bledis.setModel("Bluefruit Feather52");
-  bledis.begin();  
+  bledis.begin();
 
   // Configure and start BLE UART service
   bleuart.begin();
@@ -76,11 +76,11 @@ void setup()
 }
 
 void setupAdv(void)
-{  
+{
   // Bluefruit.Advertising.addTxPower();
   Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
   Bluefruit.Advertising.addTxPower();
-  
+
   // Include bleuart 128-bit uuid
   Bluefruit.Advertising.addService(bleuart);
 
@@ -106,7 +106,7 @@ void loop()
           commandVersion();
           break;
         }
-  
+
       case 'S': {   // Setup dimensions, components, stride...
           commandSetup();
           break;
@@ -121,12 +121,12 @@ void loop()
           commandSetBrightness();
           break;
       }
-            
+
       case 'P': {   // Set Pixel
           commandSetPixel();
           break;
       }
-  
+
       case 'I': {   // Receive new image
           commandImage();
           break;
@@ -173,7 +173,7 @@ void commandSetup() {
   neoPixelType pixelType;
   pixelType = bleuart.read();
   pixelType += bleuart.read()<<8;
-  
+
   Serial.printf("\tsize: %dx%d\n", width, height);
   Serial.printf("\tcomponents: %d\n", components);
   Serial.printf("\tstride: %d\n", stride);
@@ -240,7 +240,7 @@ void commandClearColor() {
   if (components == 3) {
     Serial.printf("\tcolor (%d, %d, %d)\n", color[0], color[1], color[2] );
   }
-  
+
   // Done
   sendResponse("OK");
 }
@@ -282,7 +282,7 @@ void commandSetPixel() {
 
 void commandImage() {
   Serial.printf("Command: Image %dx%d, %d, %d\n", width, height, components, stride);
-  
+
   // Receive new pixel buffer
   int size = width * height;
   uint8_t *base_addr = pixelBuffer;
@@ -315,4 +315,3 @@ void sendResponse(char const *response) {
     Serial.printf("Send Response: %s\n", response);
     bleuart.write(response, strlen(response)*sizeof(char));
 }
-

--- a/libraries/Bluefruit52Lib/examples/Peripheral/throughput/throughput.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/throughput/throughput.ino
@@ -40,8 +40,8 @@ void setup(void)
   // here in case you want to control this manually via PIN 19
   Bluefruit.autoConnLed(true);
 
-  Bluefruit.begin();
   Bluefruit.setName("Bluefruit52");
+  Bluefruit.begin();
   Bluefruit.setConnectCallback(connect_callback);
   Bluefruit.setDisconnectCallback(disconnect_callback);
 
@@ -103,7 +103,7 @@ void loop(void)
     // Wait for user input before trying again
     Serial.println("Connected. Send a key and press enter to start test");
     getUserInput();
-    
+
     Serial.print("Sending ");
     Serial.print(remaining);
     Serial.println(" bytes ...");


### PR DESCRIPTION
Until the Bluefruit library is properly fixed… See discussion here:
https://forums.adafruit.com/viewtopic.php?f=57&t=118731

The name will not get properly broadcasted when one first calls Bluetooth.begin and then setName
(e.g. 
Bluefruit.setName("Bluefruit52"); // set name first
Bluefruit.begin(); // begin Bluefruit after that
)