### PR TITLE
Added analog oversampling

### DIFF
--- a/cores/nRF5/Uart.cpp
+++ b/cores/nRF5/Uart.cpp
@@ -186,6 +186,7 @@ void Uart::end()
 
 void Uart::flush()
 {
+	rxBuffer.clear();
 }
 
 void Uart::IrqHandler()

--- a/cores/nRF5/wiring_analog.h
+++ b/cores/nRF5/wiring_analog.h
@@ -62,6 +62,13 @@ typedef enum _eAnalogReference
 extern void analogReference( eAnalogReference ulMode ) ;
 
 /*
+* \brief Configures the oversampling amount used to sample analog input.
+*
+* \param ulOversampling Should be set to 1, 2, 4, 8, 16, 32, 64, 128 or 256.
+*/
+extern void analogOversampling( uint32_t ulOversampling );
+
+/*
  * \brief Writes an analog value (PWM wave) to a pin.
  *
  * \param ulPin

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -31,7 +31,6 @@ extern "C" {
 static uint32_t saadcReference = SAADC_CH_CONFIG_REFSEL_Internal;
 static uint32_t saadcGain      = SAADC_CH_CONFIG_GAIN_Gain1_6;
 
-static uint32_t saadcOversampling = SAADC_OVERSAMPLE_OVERSAMPLE_Bypass;
 static bool saadcBurst = SAADC_CH_CONFIG_BURST_Disabled;
 
 #if 0 // Note: Adafruit use seperated HardwarePWM class
@@ -129,8 +128,7 @@ void analogReference( eAnalogReference ulMode )
 
 void analogOversampling( uint32_t ulOversampling )
 {
-	if(ulOversampling > 0) saadcBurst = SAADC_CH_CONFIG_BURST_Enabled; // burst mode has to be enable to use oversampling
-	else saadcBurst = SAADC_CH_CONFIG_BURST_Disabled;
+	saadcBurst = SAADC_CH_CONFIG_BURST_Enabled;
 
 	switch (ulOversampling) {
 		case 0:
@@ -164,8 +162,6 @@ void analogOversampling( uint32_t ulOversampling )
 			NRF_SAADC->OVERSAMPLE = SAADC_OVERSAMPLE_OVERSAMPLE_Over256x;
 			break;
 	}
-
-	saadcBurst = SAADC_CH_CONFIG_BURST_Enabled;
 }
 
 uint32_t analogRead( uint32_t ulPin )

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -31,6 +31,9 @@ extern "C" {
 static uint32_t saadcReference = SAADC_CH_CONFIG_REFSEL_Internal;
 static uint32_t saadcGain      = SAADC_CH_CONFIG_GAIN_Gain1_6;
 
+static uint32_t saadcOversampling = SAADC_OVERSAMPLE_OVERSAMPLE_Bypass;
+static bool saadcBurst = SAADC_CH_CONFIG_BURST_Disabled;
+
 #if 0 // Note: Adafruit use seperated HardwarePWM class
 #define PWM_COUNT 3
 
@@ -124,6 +127,47 @@ void analogReference( eAnalogReference ulMode )
   }
 }
 
+void analogOversampling( uint32_t ulOversampling )
+{
+	if(ulOversampling > 0) saadcBurst = SAADC_CH_CONFIG_BURST_Enabled; // burst mode has to be enable to use oversampling
+	else saadcBurst = SAADC_CH_CONFIG_BURST_Disabled;
+
+	switch (ulOversampling) {
+		case 0:
+		case 1:
+			saadcBurst = SAADC_CH_CONFIG_BURST_Disabled;
+			NRF_SAADC->OVERSAMPLE = SAADC_OVERSAMPLE_OVERSAMPLE_Bypass;
+			return;
+			break;
+		case 2:
+			NRF_SAADC->OVERSAMPLE = SAADC_OVERSAMPLE_OVERSAMPLE_Over2x;
+			break;
+		case 4:
+			NRF_SAADC->OVERSAMPLE = SAADC_OVERSAMPLE_OVERSAMPLE_Over4x;
+			break;
+		case 8:
+			NRF_SAADC->OVERSAMPLE = SAADC_OVERSAMPLE_OVERSAMPLE_Over8x;
+			break;
+		case 16:
+			NRF_SAADC->OVERSAMPLE = SAADC_OVERSAMPLE_OVERSAMPLE_Over16x;
+			break;
+		case 32:
+			NRF_SAADC->OVERSAMPLE = SAADC_OVERSAMPLE_OVERSAMPLE_Over32x;
+			break;
+		case 64:
+			NRF_SAADC->OVERSAMPLE = SAADC_OVERSAMPLE_OVERSAMPLE_Over64x;
+			break;
+		case 128:
+			NRF_SAADC->OVERSAMPLE = SAADC_OVERSAMPLE_OVERSAMPLE_Over128x;
+			break;
+		case 256:
+			NRF_SAADC->OVERSAMPLE = SAADC_OVERSAMPLE_OVERSAMPLE_Over256x;
+			break;
+	}
+
+	saadcBurst = SAADC_CH_CONFIG_BURST_Enabled;
+}
+
 uint32_t analogRead( uint32_t ulPin )
 {
   uint32_t pin = SAADC_CH_PSELP_PSELP_NC;
@@ -200,7 +244,8 @@ uint32_t analogRead( uint32_t ulPin )
                             | ((saadcGain                     << SAADC_CH_CONFIG_GAIN_Pos)   & SAADC_CH_CONFIG_GAIN_Msk)
                             | ((saadcReference                << SAADC_CH_CONFIG_REFSEL_Pos) & SAADC_CH_CONFIG_REFSEL_Msk)
                             | ((SAADC_CH_CONFIG_TACQ_3us      << SAADC_CH_CONFIG_TACQ_Pos)   & SAADC_CH_CONFIG_TACQ_Msk)
-                            | ((SAADC_CH_CONFIG_MODE_SE       << SAADC_CH_CONFIG_MODE_Pos)   & SAADC_CH_CONFIG_MODE_Msk);
+                            | ((SAADC_CH_CONFIG_MODE_SE       << SAADC_CH_CONFIG_MODE_Pos)   & SAADC_CH_CONFIG_MODE_Msk)
+							| ((saadcBurst					  << SAADC_CH_CONFIG_BURST_Pos)   & SAADC_CH_CONFIG_BURST_Msk);
   NRF_SAADC->CH[0].PSELN = pin;
   NRF_SAADC->CH[0].PSELP = pin;
 


### PR DESCRIPTION
Implemented analog oversampling which allows any analog pin to be automatically sampled muliple times (upto 256) when analogRead() is used. An average of the samples is then returned. Useful to improve noise performance without extra code.

Implemented Uart::flush(). Was there a specific reason for not originally implementing this? Seems like a very useful addition.