### PR TITLE
Fixed using VDD as analog reference

### DIFF
--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -98,7 +98,7 @@ void analogReference( eAnalogReference ulMode )
   switch ( ulMode ) {
     case AR_VDD4:
       saadcReference = SAADC_CH_CONFIG_REFSEL_VDD1_4;
-      saadcGain      = SAADC_CH_CONFIG_GAIN_Gain4;
+      saadcGain      = SAADC_CH_CONFIG_GAIN_Gain1_4;
       break;
     case AR_INTERNAL_3_0:
       saadcReference = SAADC_CH_CONFIG_REFSEL_Internal;


### PR DESCRIPTION
The analog gain is a bit confusing as the input range is calculated by dividing Vref by the gain not multiplying. Using VDD/4 as ref results in an input range of (VDD/4)/gain therefore if a range of 0...VDD is needed gain must be 1/4 not 4 (check p363 of product spec)