### PR TITLE
Allow HardwarePWM::addPin method to return true if _count == MAX_CHAN…

### DIFF
--- a/cores/nRF5/HardwarePWM.cpp
+++ b/cores/nRF5/HardwarePWM.cpp
@@ -78,12 +78,18 @@ void HardwarePWM::setClockDiv(uint8_t div)
  */
 bool HardwarePWM::addPin(uint8_t pin)
 {
-  VERIFY( isPinValid(pin) && (_count < MAX_CHANNELS) );
+  VERIFY( isPinValid(pin) && (_count <= MAX_CHANNELS) );
 
   // Check if pin is already configured
   for(uint8_t i=0; i<_count; i++)
   {
     if (_pwm->PSEL.OUT[i] == pin) return true;
+  }
+
+  if ((_count >= MAX_CHANNELS))
+  {
+    //Pin not already configured, but this HardwarePWM is full
+    return false;
   }
 
   pinMode(pin, OUTPUT);


### PR DESCRIPTION
Allow HardwarePWM::addPin method to return true if _count == MAX_CHANNELS, but pin passed was already configured. Return false if trying to add a new pin more than MAX_CHANNELS. fixes #92 