### PR TITLE
Use pip install . for nrfutil & how to fix it if you installed a different version

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ this available to the Arduino IDE:
 ```
 $ cd tools/nrfutil-0.5.2
 $ sudo pip install -r requirements.txt
-$ sudo python setup.py install
+$ sudo pip install .
 ```
 
 **Notes** : Don't install nrfutil from the pip package (ex. `sudo pip install nrfutil`). The
 latest nrfutil does not support DFU via Serial, and you should install the local copy of 0.5.2
-included with the BSP via the `python setup.py install` command above.
+included with the BSP via the `pip install .` command above.
 
 ## Arduino BLE Application Support
 

--- a/README.md
+++ b/README.md
@@ -45,9 +45,12 @@ $ sudo pip install -r requirements.txt
 $ sudo pip install .
 ```
 
-**Notes** : Don't install nrfutil from the pip package (ex. `sudo pip install nrfutil`). The
-latest nrfutil does not support DFU via Serial, and you should install the local copy of 0.5.2
-included with the BSP via the `pip install .` command above.
+**Notes** : Don't install nrfutil from the pip package (ex. `sudo pip install nrfutil` or even
+`sudo pip install nrfutil==0.5.2`). The latest nrfutil does not support DFU via Serial, and you
+should install the local copy of 0.5.2 included with the BSP via the `pip install .` command above.
+
+If you have installed a different version of nrfutil using pip previously, run
+`sudo pip install -U .` from the `tools/nrfutil-0.5.2` working directory.
 
 ## Arduino BLE Application Support
 


### PR DESCRIPTION
pip install . is equivalent to and has several advantages and no disadvantages that I can tell vs. python setup.py install

also added instructions on how to install the correct version if you already had one installed.