### PR TITLE
fix hardcoded pulse limits

### DIFF
--- a/libraries/Servo/src/Servo.h
+++ b/libraries/Servo/src/Servo.h
@@ -111,8 +111,8 @@ public:
   bool attached();                   // return true if this servo is attached, otherwise false 
 private:
    uint8_t servoIndex;               // index into the channel data for this servo
-   int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH    
-   int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH   
+   int16_t min;                       // minimum pulse in µs    
+   int16_t max;                       // maximum pulse in µs   
 };
 
 #endif

--- a/libraries/Servo/src/nrf52/ServoTimers.h
+++ b/libraries/Servo/src/nrf52/ServoTimers.h
@@ -28,9 +28,12 @@
  * NRF52 Only definitions
  * ---------------------
  */
-
-#define MIN_PULSE 55
-#define MAX_PULSE 284
+//PWM_PRESCALER_PRESCALER_DIV_128 -> NRF_PWM_CLK_125kHz -> resolution 8µs
+//MaxValue = 2500 -> PWM period = 20ms
+//20ms - 50Hz
+#define DUTY_CYCLE_RESOLUTION 8
+#define MAXVALUE 2500
+#define CLOCKDIV PWM_PRESCALER_PRESCALER_DIV_128
 
 // define one timer in order to have MAX_SERVOS = 12
 typedef enum { _timer1, _Nbr_16timers } timer16_Sequence_t;


### PR DESCRIPTION
As notified there https://github.com/adafruit/Adafruit_nRF52_Arduino/issues/68 :
Your implementation use hardcoded pulse limits and doesn't use user's values given to the attach function.
In addition, microseconds functions doesn't use ou return a µs value.

I had to modify the type of min and max parameters to allow storage of values up to 2500µs... maybe it had would be better to add new params (ex : minus and maxus) to avoid confusion with other ARCH...