### PR TITLE
add method sclLow() for power saving devices - fix printFloat

### DIFF
--- a/cores/nRF5/Print.cpp
+++ b/cores/nRF5/Print.cpp
@@ -228,10 +228,20 @@ size_t Print::printNumber(unsigned long n, uint8_t base)
 size_t Print::printFloat(double number, uint8_t digits)
 {
   char buf[256];
+  char format[6];
   size_t s=0;
 
-  char format[] = "%.0f";
-  format[2] += digits;
+  if (digits < 10)
+  {
+	  strcpy(format, "%.0f");
+	  format[2] += digits;
+  }
+  else
+  {
+	  strcpy(format, "%.00f");
+	  format[2] += digits / 10;
+	  format[3] += digits % 10;
+  }
 
   s = snprintf(buf, 256, format, number);
   s = write(buf, s);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -43,6 +43,7 @@ class TwoWire : public Stream
 #ifdef NRF52
     void begin(uint8_t);
 #endif
+	void sclLow(void);
     void end();
     void setClock(uint32_t);
 

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -121,6 +121,17 @@ void TwoWire::setClock(uint32_t baudrate) {
   }
 }
 
+
+void TwoWire::sclLow(void)
+{
+	NRF_GPIO->PIN_CNF[_uc_pinSCL] = ((uint32_t)GPIO_PIN_CNF_DIR_Output << GPIO_PIN_CNF_DIR_Pos)
+		| ((uint32_t)GPIO_PIN_CNF_INPUT_Connect << GPIO_PIN_CNF_INPUT_Pos)
+		| ((uint32_t)GPIO_PIN_CNF_PULL_Pullup << GPIO_PIN_CNF_PULL_Pos)
+		| ((uint32_t)GPIO_PIN_CNF_DRIVE_S0D1 << GPIO_PIN_CNF_DRIVE_Pos)
+		| ((uint32_t)GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos);
+	NRF_GPIO->OUTCLR = (1UL << _uc_pinSCL);
+}
+
 void TwoWire::end() {
   if (master)
   {


### PR DESCRIPTION
sclLow() in Wire_nRF52 useful to shut down some I2C / smbus devices between end() and start()
fixed a bug in Print.cpp where printFloat won't print (and will fail) if more than 9 digits requested.