### PR TITLE
Mk ble uart bug fixes with tx fifo enhancements

### DIFF
--- a/libraries/Bluefruit52Lib/src/services/BLEUart.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEUart.cpp
@@ -289,7 +289,7 @@ size_t BLEUart::write (const uint8_t *content, size_t len)
       {
          // write any additional data to FIFO,
          // update total number of bytes written to FIFO
-			written += _tx_fifo->write(content+written, len-written);
+         written += _tx_fifo->write(content+written, len-written);
       }
 
       // return actual number of bytes written to FIFO

--- a/libraries/Bluefruit52Lib/src/services/BLEUart.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEUart.cpp
@@ -279,7 +279,7 @@ size_t BLEUart::write (const uint8_t *content, size_t len)
     // Not up to GATT MTU, notify will be sent later by TXD timer handler
     if ( _tx_fifo->count() < (Bluefruit.Gap.getMTU( Bluefruit.connHandle() ) - 3) )
     {
-      return len;
+      return written;
     }
     else
     {

--- a/libraries/Bluefruit52Lib/src/services/BLEUart.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEUart.cpp
@@ -71,6 +71,7 @@ BLEUart::BLEUart(uint16_t fifo_depth)
   _rx_fifo_depth = fifo_depth;
 
   _tx_fifo       = NULL;
+  _tx_fifo_depth = 0;
   _tx_buffered   = 0;
   _buffered_th   = NULL;
 }
@@ -147,20 +148,21 @@ void BLEUart::setRxCallback( rx_callback_t fp)
  * Note: packet is sent right away if it reach MTU bytes
  * @param enable true or false
  */
-void BLEUart::bufferTXD(uint8_t enable)
+void BLEUart::bufferTXD(uint8_t enable, uint16_t fifo_depth)
 {
   _tx_buffered = enable;
+  _tx_fifo_depth = fifo_depth;
 
   if ( enable )
   {
     // enable cccd callback to start timer when enabled
     _txd.setCccdWriteCallback(bleuart_txd_cccd_cb);
 
-    // Create FIFO for TX TODO Larger MTU Size
+    // Create FIFO for TX
     if ( _tx_fifo == NULL )
     {
       _tx_fifo = new Adafruit_FIFO(1);
-      _tx_fifo->begin( Bluefruit.Gap.getMaxMtuByConnCfg(CONN_CFG_PERIPHERAL) );
+      _tx_fifo->begin(_tx_fifo_depth);
     }
   }else
   {

--- a/libraries/Bluefruit52Lib/src/services/BLEUart.h
+++ b/libraries/Bluefruit52Lib/src/services/BLEUart.h
@@ -60,7 +60,7 @@ class BLEUart : public BLEService, public Stream
 
     bool notifyEnabled (void);
     void setRxCallback (rx_callback_t fp);
-    void bufferTXD     (uint8_t enable);
+    void bufferTXD     (uint8_t enable, uint16_t fifo_depth = BLE_UART_DEFAULT_FIFO_DEPTH);
 
     // Stream API
     virtual int       read       ( void );
@@ -86,6 +86,7 @@ class BLEUart : public BLEService, public Stream
 
     // TXD
     Adafruit_FIFO*    _tx_fifo;
+    uint16_t          _tx_fifo_depth;
     uint8_t           _tx_buffered;
     TimerHandle_t     _buffered_th;
 


### PR DESCRIPTION
While using this board support package for a project, I ran some tests using a modified version of the bleuart sketch and the Adafruit Bluefruit LE Connect app on my Samsung tablet, and found some problems with the BLEUart service:

1. With TX buffering turned off and sending more than 20 characters from the Serial Monitor, only upto 20 would be transmitted, even the bleuart.write() function indicated all of them had been sent.

2. With TX buffering turned off and sending more than 20 characters from the Serial Monitor, not all them would be transmitted, even the bleuart.write() function indicated all of them had been sent.  Moreover, the ones that did get sent would be sent out-of-order somewhere past the 20th character.

3. The TX buffer, when enabled, was set to a fixed size not settable by the user.

Here are some screenshots from the Arduino Serial Monitor and my Android tablet illustrating the problems.

In this case, 123456789012345678901234567890 (with a LF terminator) was sent.  Notice how they are out of order after the 20th character ('0', or 0x30) was sent.
![no-fixes-send-123456789012345678901234567890-hex](https://user-images.githubusercontent.com/10409565/39342601-c1183c9c-49a6-11e8-9a06-8d16412d693a.png)

In this case, ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz (with a LF terminator) was sent.  Notice how they are out of order after the 20th character ('T', or 0x54) was sent.
![no-fixes-send-abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz-hex](https://user-images.githubusercontent.com/10409565/39342604-c1397952-49a6-11e8-8f37-55a8d33058a0.png)

Here, the Serial Monitor reports all characters (31 for 123456789012345678901234567890, 63 for ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz) were sent, even though they were not.
![serial-monitor-no-fixes](https://user-images.githubusercontent.com/10409565/39342605-c147bb16-49a6-11e8-844c-f3fef80ba44c.png)

Within my development branch (mk_BLE_UART_bug_fixes_with_TX_FIFO_enhancements), I have attempted to fix all three of these problems.  I have run some tests with these changes, and thus far all 3 problems have been corrected. 

Here are some screenshots from the Arduino Serial Monitor and my Android tablet illustrating the same tests after the fixes.

In these test cases, the TX buffer is turned off.

Only 20 characters, as expected, were sent.
![with-fixes-send-12345678901234567890-hex-no-tx-buffer](https://user-images.githubusercontent.com/10409565/39342609-c1871964-49a6-11e8-947c-f04bcf87b09e.png)

Again, only 20 characters, as expected, were sent.
![with-fixes-send-abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz-hex-no-tx-buffer](https://user-images.githubusercontent.com/10409565/39342611-c1a4a4a2-49a6-11e8-8aab-cbd45813ed35.png)

Notice how bleuart.write() now returns the actual number of characters sent.
![serial-monitor-with-fixes-tx-buffer-off](https://user-images.githubusercontent.com/10409565/39342606-c156ad06-49a6-11e8-80fd-52919001b903.png)

In these test cases, the TX buffer is turned on.

21 characters (all of them) were sent.
![with-fixes-12345678901234567890-hex](https://user-images.githubusercontent.com/10409565/39342608-c17697ba-49a6-11e8-811e-b9ae730aeccd.png)

63 characters (all of them) were sent.
![with-fixes-send-abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz-hex](https://user-images.githubusercontent.com/10409565/39342610-c195c342-49a6-11e8-9d1d-e65032fe09a3.png)

Again, bleuart.write() now returns the actual number of characters sent.
![serial-monitor-with-fixes-tx-buffer-on](https://user-images.githubusercontent.com/10409565/39342607-c166b692-49a6-11e8-9053-e1acbcf8acda.png)

Here the modified version of the bleuart sketch I used for testing:

```
/*********************************************************************`
 This is an example for our nRF52 based Bluefruit LE modules

 Pick one up today in the adafruit shop!

 Adafruit invests time and resources providing this open source code,
 please support Adafruit and open-source hardware by purchasing
 products from Adafruit!

 MIT license, check LICENSE for more information
 All text above, and the splash screen below must be included in
 any redistribution
*********************************************************************/
#include <bluefruit.h>

// BLE Service
BLEDis  bledis;
BLEUart bleuart;
BLEBas  blebas;

// Software Timer for blinking RED LED
SoftwareTimer blinkTimer;
static const int BLEUARTTXBufferSize = 1024;
static const int SerialBaudRate = 9600;
static const boolean EnableTxBuffering = true;

void setup()
{
  Serial.begin(SerialBaudRate);
  Serial.println("Bluefruit52 BLEUART Example");
  Serial.println("---------------------------\n");

  // Initialize blinkTimer for 1000 ms and start it
  blinkTimer.begin(1000, blink_timer_callback);
  blinkTimer.start();

  // Setup the BLE LED to be enabled on CONNECT
  // Note: This is actually the default behaviour, but provided
  // here in case you want to control this LED manually via PIN 19
  Bluefruit.autoConnLed(true);

  // Config the peripheral connection with maximum bandwidth 
  // more SRAM required by SoftDevice
  // Note: All config***() function must be called before begin()
  Bluefruit.configPrphBandwidth(BANDWIDTH_MAX);

  Bluefruit.begin();
  // Set max power. Accepted values are: -40, -30, -20, -16, -12, -8, -4, 0, 4
  Bluefruit.setTxPower(4);
  Bluefruit.setName("Bluefruit52");
  //Bluefruit.setName(getMcuUniqueID()); // useful testing with multiple central connections
  Bluefruit.setConnectCallback(connect_callback);
  Bluefruit.setDisconnectCallback(disconnect_callback);

  // Configure and Start Device Information Service
  bledis.setManufacturer("Adafruit Industries");
  bledis.setModel("Bluefruit Feather52");
  bledis.begin();

  // Configure and Start BLE Uart Service
  bleuart.begin();

  // turn on transmit data buffering
  if(EnableTxBuffering)
  {
    Serial.println("Enabling TX buffering");
    bleuart.bufferTXD(1);
  }

  // Start BLE Battery Service
  blebas.begin();
  blebas.write(100);

  // Set up and start advertigithub add screenshot to readmesing
  startAdv();

  Serial.println("Please use Adafruit's Bluefruit LE app to connect in UART mode");
  Serial.println("Once connected, enter character(s) that you wish to send");
}

void startAdv(void)
{
  // Advertising packet
  Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
  Bluefruit.Advertising.addTxPower();

  // Include bleuart 128-bit uuid
  Bluefruit.Advertising.addService(bleuart);

  // Secondary Scan Response packet (optional)
  // Since there is no room for 'Name' in Advertising packet
  Bluefruit.ScanResponse.addName();
  
  /* Start Advertising
   * - Enable auto advertising if disconnected
   * - Interval:  fast mode = 20 ms, slow mode = 152.5 ms
   * - Timeout for fast mode is 30 seconds
   * - Start(timeout) with timeout = 0 will advertise forever (until connected)
   * 
   * For recommended advertising interval
   * https://developer.apple.com/library/content/qa/qa1931/_index.html   
   */
  Bluefruit.Advertising.restartOnDisconnect(true);
  Bluefruit.Advertising.setInterval(32, 244);    // in unit of 0.625 ms
  Bluefruit.Advertising.setFastTimeout(30);      // number of seconds in fast mode
  Bluefruit.Advertising.start(0);                // 0 = Don't stop advertising after n seconds  
}

void loop()
{
  // Forward data from HW Serial to BLEUART
  while (Serial.available())
  {
    // Delay to wait for enough input, since we have a limited transmission buffer
    delay(2);

    uint8_t buf[64];
    int count = Serial.readBytes(buf, sizeof(buf));
    int bytesWritten = bleuart.write( buf, count );

    Serial.print(count);
    Serial.print(" bytes to send, ");
    Serial.print(bytesWritten);
    Serial.println(" sent");
  }

  // Forward from BLEUART to HW Serial
  while ( bleuart.available() )
  {
    uint8_t ch;
    ch = (uint8_t) bleuart.read();
    Serial.write(ch);
  }

  // Request CPU to enter low-power mode until an event/interrupt occurs
  waitForEvent();
}

void connect_callback(uint16_t conn_handle)
{
  char central_name[32] = { 0 };
  Bluefruit.Gap.getPeerName(conn_handle, central_name, sizeof(central_name));

  Serial.print("Connected to ");
  Serial.println(central_name);
}

void disconnect_callback(uint16_t conn_handle, uint8_t reason)
{
  (void) conn_handle;
  (void) reason;

  Serial.println();
  Serial.println("Disconnected");
}github add screenshot to readme

/**
 * Software Timer callback is invoked via a built-in FreeRTOS thread with
 * minimal stack size. Therefore it should be as simple as possible. If
 * a periodically heavy task is needed, please use Scheduler.startLoop() to
 * create a dedicated task for it.
 * 
 * More information http://www.freertos.org/RTOS-software-timer.html
 */
void blink_timer_callback(TimerHandle_t xTimerID)
{
  (void) xTimerID;
  digitalToggle(LED_RED);
}

/**
 * RTOS Idle callback is automatically invoked by FreeRTOS
 * when there are no active threads. E.g when loop() calls delay() and
 * there is no bluetooth or hw event. This is the ideal place to handle
 * background data.
 * 
 * NOTE: FreeRTOS is configured as tickless idle mode. After this callback
 * is executed, if there is time, freeRTOS kernel will go into low power mode.
 * Therefore waitForEvent() should not be called in this callback.
 * http://www.freertos.org/low-power-tickless-rtos.html
 * 
 * WARNING: This function MUST NOT call any blocking FreeRTOS API 
 * such as delay(), xSemaphoreTake() etc ... for more information
 * http://www.freertos.org/a00016.html
 */
void rtos_idle_callback(void)
{
  // Don't call any other FreeRTOS blocking API()
  // Perform background task(s) here
}

```

Please take a look at these changes, and if they seem good, please incorporate them in the board support package.

Thanks for your help

Michael Kirkhart

