### PR TITLE
Fix upload bootloader on Mac OS

### DIFF
--- a/programmers.txt
+++ b/programmers.txt
@@ -7,6 +7,7 @@ nrfjprog.program.tool=bootburn
 nrfjprog.program.path=
 nrfjprog.program.cmd=nrfjprog
 nrfjprog.program.cmd.windows=nrfjprog.exe
+nrfjprog.program.cmd.macosx=/usr/local/bin/nrfjprog
 
 nrfjprog.program.pattern="{program.path}{program.cmd}" --program "{runtime.platform.path}/bin/bootloader/{build.variant}/{build.bootfile}.hex" -f nrf52 --chiperase --reset
 


### PR DESCRIPTION
Unless I am doing something silly, my symlink to /usr/local/bin/nrfjprog wasn't getting picked up by the code and so bootloader upload was failing (as just nrfjprog was getting called, and I don't think I should be setting symlinks to /bin). If I am getting something very wrong here please let me know so I can fix at my end!