### PR TITLE
Fixed output of dbgDumpMemory when buffer size > 255 bytes

### DIFF
--- a/cores/nRF5/debug.cpp
+++ b/cores/nRF5/debug.cpp
@@ -179,13 +179,13 @@ void dbgDumpMemory(void const *buf, uint8_t size, uint16_t count, bool printOffs
   uint8_t const *buf8 = (uint8_t const *) buf;
   
   uint8_t format_size = 2 * size;
-  if ( count*size > UINT8_MAX  ) format_size *= 2;
-  if ( count*size > UINT16_MAX ) format_size *= 2;
+  if ( count*size > UINT8_MAX  ) offset_fmt_size *= 2;
+  if ( count*size > UINT16_MAX ) offset_fmt_size *= 2;
 
-  char format[] = "%00lX";
-  format[2] += format_size;
+  char format[] = "%02lX";
 
-  char offset_fmt[] = "%02lX: ";
+  char offset_fmt[] = "%00lX: ";
+  offset_fmt[2] += offset_fmt_size;
 
   const uint8_t item_per_line = 16 / size;
 

--- a/cores/nRF5/debug.cpp
+++ b/cores/nRF5/debug.cpp
@@ -177,14 +177,15 @@ void dbgPrintVersion(void)
 void dbgDumpMemory(void const *buf, uint8_t size, uint16_t count, bool printOffset)
 {
   uint8_t const *buf8 = (uint8_t const *) buf;
+  
+  uint8_t format_size = 2 * size;
+  if ( count*size > UINT8_MAX  ) format_size *= 2;
+  if ( count*size > UINT16_MAX ) format_size *= 2;
 
   char format[] = "%00lX";
-  format[2] += 2*size;
+  format[2] += format_size;
 
   char offset_fmt[] = "%02lX: ";
-
-  if ( count*size > UINT8_MAX  ) format[2] *= 2;
-  if ( count*size > UINT16_MAX ) format[2] *= 2;
 
   const uint8_t item_per_line = 16 / size;
 


### PR DESCRIPTION
Output of `dbgDumpMemory` is completely broken when buffer size is > 255 because the code to handle that case multiplies a char (instead of its int value) by 2. This fixes the problem.

Before the fix, the output of dumping a buffer between 2^8 and 2^16 bytes long looks like:

    00:  255lX 255lX 255lX 255lX

because `‘2’ * 2` happens to be `‘d’` so the format string ends up being `“%0dlx”`. Beyond 2^16 bytes, it would fail even harder, as `‘d’ * 2` isn’t a valid format character. I didn’t try it. 

This is an untested code change; I am not set up to build the core and test it here, I just ran into this bug while debugging a library I am working on.