### PR TITLE
Fix upstream issue #171: Better choice of pin interrupt priority

### DIFF
--- a/cores/nRF5/WInterrupts.c
+++ b/cores/nRF5/WInterrupts.c
@@ -42,7 +42,7 @@ static void __initialize()
 
   NVIC_DisableIRQ(GPIOTE_IRQn);
   NVIC_ClearPendingIRQ(GPIOTE_IRQn);
-  NVIC_SetPriority(GPIOTE_IRQn, 1);
+  NVIC_SetPriority(GPIOTE_IRQn, 2);
   NVIC_EnableIRQ(GPIOTE_IRQn);
 }
 


### PR DESCRIPTION
Nordic SoftDevice needs to have control over lowest priority interrupts
for reliable, timing sensitive operation. If user code tries to use
such a low priority level, SoftDevice refuses to start.
One way to overcome this limitation is to start the SoftDevice before
attaching pin change interrupts, though in such a case, SD will
cap the effective priority of the user interrupt anyway and it is
a common mistake API users do. This change simply changes the priority
to 2, which is legal (for fast interrupt handlers anyway) under SoftDevice,
no matter if attached before of after SD start.