### PR TITLE
Update BLEScanner.cpp

### DIFF
--- a/libraries/Bluefruit52Lib/src/BLEScanner.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEScanner.cpp
@@ -387,6 +387,7 @@ void BLEScanner::_eventHandler(ble_evt_t* evt)
     case BLE_GAP_EVT_TIMEOUT:
       if (evt->evt.gap_evt.params.timeout.src == BLE_GAP_TIMEOUT_SRC_SCAN)
       {
+        _runnning = false;
         if (_stop_cb) ada_callback(NULL, _stop_cb);
       }
     break;


### PR DESCRIPTION
According to this post on the Nordic DevZone Forum (https://devzone.nordicsemi.com/f/nordic-q-a/14643/s130-permanent-advertising-scanning-during-operation), scanning automatically stops after receiving a BLE_GAP_EVT_TIMEOUT{BLE_GAP_TIMEOUT_SRC_SCAN} event. The _runnning [sic] flag should be set to false in this case.