### PR TITLE
DO NOT MERGE: Supports setting PHY for extended range

### DIFF
--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -254,7 +254,7 @@ err_t AdafruitBluefruit::begin(uint8_t prph_count, uint8_t central_count)
       .accuracy      = NRF_CLOCK_LF_ACCURACY_20_PPM
   };
 #elif defined( USE_LFRC )
-  nrf_clock_lf_cfg_t clock_cfg = 
+  nrf_clock_lf_cfg_t clock_cfg =
   {
       // LXRC
       .source        = NRF_CLOCK_LF_SRC_RC,
@@ -536,6 +536,41 @@ uint16_t AdafruitBluefruit::getApperance(void)
   uint16_t appear = 0;
   (void) sd_ble_gap_appearance_get(&appear);
   return appear;
+}
+
+bool AdafruitBluefruit::setPhy(int8_t phy)
+{
+#if defined(NRF52832_XXAA)
+int8_t const accepted[] = { BLE_GAP_PHY_AUTO, BLE_GAP_PHY_1MBPS, BLE_GAP_PHY_2MBPS };
+#elif defined( NRF52840_XXAA)
+int8_t const accepted[] = { BLE_GAP_PHY_AUTO, BLE_GAP_PHY_1MBPS, BLE_GAP_PHY_2MBPS,
+                            BLE_GAP_PHY_CODED };
+#endif
+
+  // Check if phy is valid value
+  uint32_t i;
+  for (i=0; i<sizeof(accepted); i++)
+  {
+    if (accepted[i] == phy) break;
+  }
+  VERIFY(i < sizeof(accepted));
+
+  // Apply if connected
+  ble_gap_phys_t phys;
+  phys.tx_phys = phy;
+  phys.rx_phys = phy;
+  if ( _conn_hdl != BLE_CONN_HANDLE_INVALID )
+  {
+    VERIFY_STATUS( sd_ble_gap_phy_update(_conn_hdl, &phys), false );
+  }
+  _phy = phy;
+
+  return true;
+}
+
+int8_t AdafruitBluefruit::getPhy(void)
+{
+  return _phy;
 }
 
 /*------------------------------------------------------------------*/

--- a/libraries/Bluefruit52Lib/src/bluefruit.h
+++ b/libraries/Bluefruit52Lib/src/bluefruit.h
@@ -150,6 +150,9 @@ class AdafruitBluefruit
     void     autoConnLed        (bool enabled);
     void     setConnLedInterval (uint32_t ms);
 
+    bool     setPhy             (int8_t phy);
+    int8_t   getPhy             (void);
+
     /*------------------------------------------------------------------*/
     /* GAP, Connections and Bonding
      *------------------------------------------------------------------*/
@@ -217,6 +220,7 @@ class AdafruitBluefruit
     TimerHandle_t _led_blink_th;
     bool _led_conn;
 
+    int8_t _phy;
     BLEDfu _dfu_svc;
 
     uint16_t _conn_hdl;


### PR DESCRIPTION
Adds `setPhy`/`getPhy` for setting PHY. On nRF52840, allows setting PHY
to `BLE_GAP_PHY_CODED` to support extended range.

This work compiles but is not yet field-tested.

Implements #82.