### PR TITLE
Bug Fix: Incorrect cast on BLECharacteristic::read32()

### DIFF
--- a/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
+++ b/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
@@ -484,7 +484,7 @@ uint16_t BLECharacteristic::read16(void)
 
 uint32_t BLECharacteristic::read32(void)
 {
-  uint16_t num;
+  uint32_t num;
   return read(&num, sizeof(num)) ? num : 0;
 }
 


### PR DESCRIPTION
`read32()` does not work correctly when payload > 0x0000ffff.
Because `read32()` has incorrect cast to`uint16_t` inside the function...