### PR TITLE
Fix return statements

### DIFF
--- a/cores/nRF5/WInterrupts.c
+++ b/cores/nRF5/WInterrupts.c
@@ -86,7 +86,7 @@ int attachInterrupt(uint32_t pin, voidFuncPtr callback, uint32_t mode)
       break;
 
     default:
-      return;
+      return 0;
   }
 
   for (int ch = 0; ch < NUMBER_OF_GPIO_TE; ch++) {

--- a/cores/nRF5/main.cpp
+++ b/cores/nRF5/main.cpp
@@ -114,8 +114,9 @@ int _write (int fd, const void *buf, size_t count)
 
   if ( Serial )
   {
-    Serial.write( (const uint8_t *) buf, count);
+    return Serial.write( (const uint8_t *) buf, count);
   }
+  return 0;
 }
 
 }

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientHidAdafruit.cpp
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientHidAdafruit.cpp
@@ -81,6 +81,8 @@ bool BLEClientHidAdafruit::begin(void)
   // set notify callback
   _kbd_boot_input.setNotifyCallback(kbd_client_notify_cb);
   _mse_boot_input.setNotifyCallback(mse_client_notify_cb);
+
+  return true;
 }
 
 void BLEClientHidAdafruit::setKeyboardReportCallback(kbd_callback_t fp)
@@ -140,12 +142,12 @@ bool BLEClientHidAdafruit::keyboardPresent(void)
 
 bool BLEClientHidAdafruit::enableKeyboard(void)
 {
-  _kbd_boot_input.enableNotify();
+  return _kbd_boot_input.enableNotify();
 }
 
 bool BLEClientHidAdafruit::disableKeyboard(void)
 {
-  _kbd_boot_input.disableNotify();
+  return _kbd_boot_input.disableNotify();
 }
 
 void BLEClientHidAdafruit::_handle_kbd_input(uint8_t* data, uint16_t len)
@@ -171,12 +173,12 @@ bool BLEClientHidAdafruit::mousePresent(void)
 
 bool BLEClientHidAdafruit::enableMouse(void)
 {
-  _mse_boot_input.enableNotify();
+  return _mse_boot_input.enableNotify();
 }
 
 bool BLEClientHidAdafruit::disableMouse(void)
 {
-  _mse_boot_input.disableNotify();
+  return _mse_boot_input.disableNotify();
 }
 
 void BLEClientHidAdafruit::_handle_mse_input(uint8_t* data, uint16_t len)

--- a/libraries/Bluefruit52Lib/src/services/EddyStone.cpp
+++ b/libraries/Bluefruit52Lib/src/services/EddyStone.cpp
@@ -81,7 +81,7 @@ EddyStoneUrl::EddyStoneUrl(int8_t rssiAt0m, const char* url)
   _url  = url;
 }
 
-bool EddyStoneUrl::setUrl(const char* url)
+void EddyStoneUrl::setUrl(const char* url)
 {
   _url = url;
 }

--- a/libraries/Bluefruit52Lib/src/services/EddyStone.h
+++ b/libraries/Bluefruit52Lib/src/services/EddyStone.h
@@ -59,7 +59,7 @@ class EddyStoneUrl
     EddyStoneUrl(void);
     EddyStoneUrl(int8_t rssiAt0m, const char* url = NULL);
 
-    bool setUrl(const char* url);
+    void setUrl(const char* url);
     void setRssi(int8_t rssiAt0m);
 
     bool start(void);


### PR DESCRIPTION
This fixes several warnings about not returning values when there is an expected return value.

In particular the missing returns in BLEClientHidAdafruit where actually causing an issue when using PlatformIO to compile the central_hid.ino example where calling hid.begin() would cause the board to crash and hang. 