### PR TITLE
LittleFS extension rework

### DIFF
--- a/libraries/FileSystem/src/InternalFS.h
+++ b/libraries/FileSystem/src/InternalFS.h
@@ -58,6 +58,12 @@ class LittleFS: public BluefruitFS::FileSystemClass
     bool rmdir_r (char const *filepath);
     bool format (bool eraseall);
 
+  protected:
+    bool _begun;
+    bool _mounted;
+
+    LittleFS (lfs_size_t read_size, lfs_size_t prog_size, lfs_size_t block_size, lfs_size_t block_count, lfs_size_t lookahead);
+    
     // Internal API: shouldn't be used by Arduino sketch
     virtual size_t _f_write (void* fhdl, uint8_t const *buf, size_t size);
     virtual int _f_read (void* fhdl, void *buf, uint16_t nbyte);
@@ -67,17 +73,26 @@ class LittleFS: public BluefruitFS::FileSystemClass
     virtual uint32_t _f_position (void* fhdl);
     virtual uint32_t _f_size (void* fhdl);
 
+    // Raw flash opperations, override to use an external flash chip
+    virtual int _flash_read (lfs_block_t block, lfs_off_t off, void *buffer, lfs_size_t size);
+    virtual int _flash_prog (lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size);
+    virtual int _flash_erase (lfs_block_t block);
+    virtual void _flash_erase_all();
+    virtual int _flash_sync ();
+
     virtual BluefruitFS::File _f_openNextFile (void* fhdl, char const* cwd, uint8_t mode);
     virtual void _f_rewindDirectory (void* fhdl);
-
   private:
     struct lfs_config _lfs_cfg;
     lfs_t _lfs;
-    bool _begun;
-    bool _mounted;
 
     BluefruitFS::File _open_file (char const *filepath, uint8_t mode);
     BluefruitFS::File _open_dir (char const *filepath);
+
+    static int _iflash_read (const struct lfs_config *c, lfs_block_t block, lfs_off_t off, void *buffer, lfs_size_t size);
+    static int _iflash_prog (const struct lfs_config *c, lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size);
+    static int _iflash_erase (const struct lfs_config *c, lfs_block_t block);
+    static int _iflash_sync (const struct lfs_config *c);
 };
 
 extern LittleFS InternalFS;


### PR DESCRIPTION
Restructured so the class can be extended to add support for external flash chips. This would be used as follows:

ExtFlashFS.h

```C++
#ifndef EXT_FLASH_FS_MANAGER_H
#define EXT_FLASH_FS_MANAGER_H

// Internal Flash uses ARM Little FileSystem
// https://github.com/ARMmbed/littlefs
#include "InternalFS.h"

class ExtLittleFS : public LittleFS
{
  protected:
    virtual int _flash_read (lfs_block_t block, lfs_off_t off, void *buffer, lfs_size_t size);
    virtual int _flash_prog (lfs_block_t block, lfs_off_t off, const void *buffer, lfs_size_t size);
    virtual int _flash_erase (lfs_block_t block);
    virtual void _flash_erase_all();
    virtual int _flash_sync ();

  public:
    ExtLittleFS(void);
    ~ExtLittleFS();

    bool begin(void);
};

extern ExtLittleFS ExtFlashFS;

#endif // !EXT_FLASH_FS_MANAGER_H
```

ExtFlashFS.cpp

```C++
#ifndef ENABLE_DEBUG_FLASH_FS
#undef ENABLE_DEBUG
#endif

#include "ExtFlashFS.h"
#include "MicroDebug.h"
#include "SPIFlash.h"

#ifndef ENABLE_DEBUG_FLASH_FS
#define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, NULL)
#else
#define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, dbg_strerr_lfs)
#endif

// External SPI Flash uses ARM Little FileSystem
// 
//    | | |     .---._____
//   .-----.   |          |
// --|o    |---| littlefs |
// --|     |---|          |
//   '-----'   '----------'
//    | | |
// 
// https://github.com/ARMmbed/littlefs

//! Default Flash Chip
//! CYPRESS
#define CYPRESS_FLASH_JEDEC_ID  0x0160 

//! ISSI Flash
//! jedec_MANUF_ID = 0x9D
//! jedec_MEM_TYPE = 0x60
//! jedec_CAPACITY = 0x19
#define ISSI_FLASH_JEDEC_ID     0x9D60

#define FLASH_BLOCK_SIZE      0x1000 // 4 kByte block size

#define LFS_FLASH_ADDR        0x00000
#define LFS_FLASH_TOTAL_SIZE  0x2000000
#define LFS_BLOCK_SIZE        FLASH_BLOCK_SIZE 
#define LFS_READ_SIZE         (LFS_BLOCK_SIZE / 16) 
#define LFS_PROG_SIZE         (LFS_READ_SIZE * 1)

static SPIFlash flash(SS, CYPRESS_FLASH_JEDEC_ID); // 0x0160 is Cypress Flash JEDEC code

ExtLittleFS ExtFlashFS;

static inline uint32_t lba2addr(uint32_t block)
{
  return ((uint32_t) LFS_FLASH_ADDR) + block * LFS_BLOCK_SIZE;
}

static inline void flashWait() {
  while(flash.busy()){
    delay(10);
  }
}

ExtLittleFS::ExtLittleFS(void) : 
  LittleFS( LFS_READ_SIZE, LFS_PROG_SIZE, LFS_BLOCK_SIZE, LFS_FLASH_TOTAL_SIZE / LFS_BLOCK_SIZE, 128)
{
}

ExtLittleFS::~ExtLittleFS()
{
}

bool ExtLittleFS::begin (void)
{
  if ( _begun ) return true;

  //! Initialize SPI
  DBUGLN("Initialising SPI bus");
  SPI.begin();

  //! Initialize flash and Check for Cycpress Flash chip ID
  DBUGLN("Initialising flash");
  if (true == flash.initialize()) 
  {
    // Serial.println("Init Flash OK!");
  }
  else
  {
    //! Check for ISSI Flash ID
    uint16_t jedecID = flash.readDeviceId();
    if ( (0 == jedecID) || (ISSI_FLASH_JEDEC_ID == jedecID))
    {
      // Serial.println("Init Flash OK!");
    }
    else
    {    
      Serial.print("JedecID = ");
      Serial.println(jedecID);

      Serial.println("Init Flash FAIL!");
    }
  }

  //===========================================================================
  // delay 30ms to allow Flash to startup
  // This is required because the BleManager needs to read the flash via
  // the deviceManager for the BLE DeviceName
  //===========================================================================
  flashWait();

  return LittleFS::begin();
}

int ExtLittleFS::_flash_read (lfs_block_t block, lfs_off_t off, void *buffer, lfs_size_t size)
{
  DBUGF("_flash_read block %d, off %d, buffer %p, size %d", block, off, buffer, size);

  uint32_t addr = lba2addr(block) + off;
  flash.readBytes(addr, buffer, size);
  flashWait();

  return 0;
}

// Program a region in a block. The block must have previously
// been erased. Negative error codes are propogated to the user.
// May return LFS_ERR_CORRUPT if the block should be considered bad.
int ExtLittleFS::_flash_prog (lfs_block_t block, lfs_off_t off, const void *buffer,
                         lfs_size_t size)
{
  DBUGF("_flash_prog block %d, off %d, buffer %p, size %d", block, off, buffer, size);

  uint32_t addr = lba2addr(block) + off;
  flash.writeBytes(addr, buffer, size);
  flashWait();

  return 0;
}

// Erase a block. A block must be erased before being programmed.
// The state of an erased block is undefined. Negative error codes
// are propogated to the user.
// May return LFS_ERR_CORRUPT if the block should be considered bad.
int ExtLittleFS::_flash_erase (lfs_block_t block)
{
  DBUGF("_flash_erase block %d", block);

  uint32_t addr = lba2addr(block);
  flash.blockErase4K(addr);
  flashWait();

  return 0;
}

void ExtLittleFS::_flash_erase_all()
{
  DBUGF("_flash_erase_all");

  for ( uint32_t addr = LFS_FLASH_ADDR; addr < LFS_FLASH_ADDR + LFS_FLASH_TOTAL_SIZE; addr += FLASH_BLOCK_SIZE )
  {
    flash.blockErase4K(addr);
  }
}

// Sync the state of the underlying block device. Negative error codes
// are propogated to the user.
int ExtLittleFS::_flash_sync()
{
  DBUGF("_flash_sync");

  return 0;
}
```

