### PR TITLE
Allow the task stack sizes to be configured

### DIFF
--- a/cores/nRF5/utility/AdaCallback.h
+++ b/cores/nRF5/utility/AdaCallback.h
@@ -38,9 +38,18 @@
 
 #include "common_inc.h"
 
+#ifndef CFG_CALLBACK_TASK_STACKSIZE
 #define CFG_CALLBACK_TASK_STACKSIZE     (512*2)
+#endif
+
+#ifndef CFG_CALLBACK_QUEUE_LENGTH
 #define CFG_CALLBACK_QUEUE_LENGTH       20
+#endif
+
+#ifndef CFG_CALLBACK_TIMEOUT
 #define CFG_CALLBACK_TIMEOUT            100
+#endif
+
 
 #ifdef __cplusplus
 extern "C"{

--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -42,11 +42,23 @@
 #include "usb/usb.h"
 #endif
 
+#ifndef CFG_BLE_TX_POWER_LEVEL
 #define CFG_BLE_TX_POWER_LEVEL           0
-#define CFG_DEFAULT_NAME                 "Bluefruit52"
+#endif
 
+#ifndef CFG_DEFAULT_NAME
+#define CFG_DEFAULT_NAME                 "Bluefruit52"
+#endif
+
+
+#ifndef CFG_BLE_TASK_STACKSIZE
 #define CFG_BLE_TASK_STACKSIZE          (512*3)
+#endif
+
+#ifndef CFG_SOC_TASK_STACKSIZE
 #define CFG_SOC_TASK_STACKSIZE          (200)
+#endif
+
 
 AdafruitBluefruit Bluefruit;
 


### PR DESCRIPTION
(and some other CFG_ items that were in the same files)

This is because the default memory allocations are quite conservative assuming that folks will do lots of work in the callbacks etc (which is fairly good assumption). However this can lead to a lot of 'wasted' RAM. The `dbgMemInfo` tool (which is great BTW) can then be used to look at the memory usage and the values can be fine tuned (at least with PlatformIO).

