### PR TITLE
loopback functionality for ancs

### DIFF
--- a/libraries/Bluefruit52Lib/examples/Peripheral/ancs_loopback/ancs_loopback.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/ancs_loopback/ancs_loopback.ino
@@ -1,0 +1,185 @@
+#include <bluefruit.h>
+
+BLEDis bledis;
+BLEClientDis bleClientDis;
+BLEAncsLoopback bleancs;
+
+char buffer[128];
+
+const uint8_t ANCS_LOOPBACK_GATT_SERVICE[] =
+{
+  0xFD, 0xC2, 0x3A, 0x2B, 0xEC, 0xE2, 0xEE, 0x9B, 
+  0x94, 0x49, 0x6F, 0x6E, 0x8B, 0x13, 0xF6, 0x39
+};
+
+const uint8_t ANCS_LOOPBACK_GATT_NOTIFICATION_CHR[] =
+{
+  0x57, 0xD7, 0x34, 0xB0, 0x0C, 0x78, 0x2F, 0x94, 
+  0xCB, 0x4D, 0x7C, 0x73, 0x28, 0x30, 0x94, 0x76
+};
+
+const uint8_t ANCS_LOOPBACK_GATT_CONTROL_POINT_CHR[] =
+{
+  0x75, 0x0B, 0xE6, 0x0F, 0xFF, 0x3E, 0xB3, 0xB5, 
+  0xA3, 0x49, 0xDA, 0x24, 0x7C, 0xD4, 0x6F, 0xD2
+};
+
+const uint8_t ANCS_LOOPBACK_GATT_DATA_SOURCE_CHR[] =
+{
+  0x5B, 0x7B, 0xA8, 0x73, 0xD7, 0xB4, 0xA6, 0xA4, 
+  0x83, 0x4E, 0x4A, 0xB2, 0x8C, 0x5F, 0xA3, 0x62
+};
+
+BLEService        loopbackGattService     = BLEService       (ANCS_LOOPBACK_GATT_SERVICE);
+BLECharacteristic loopbackNotificationChr = BLECharacteristic(ANCS_LOOPBACK_GATT_NOTIFICATION_CHR);
+BLECharacteristic loopbackControlPointChr = BLECharacteristic(ANCS_LOOPBACK_GATT_CONTROL_POINT_CHR);
+BLECharacteristic loopbackDataSourceChr   = BLECharacteristic(ANCS_LOOPBACK_GATT_DATA_SOURCE_CHR);
+
+void setup () 
+{
+  Serial.begin(115200);
+  while (!Serial) delay(10);
+
+  Serial.println(F("Ancs characteristics loopback"));
+  Serial.println(F("-----------------------------\n"));
+
+  Bluefruit.configPrphConn(128, 3, 1, 1);
+  Bluefruit.begin();
+  // Set max power. Accepted values are: -40, -30, -20, -16, -12, -8, -4, 0, 4
+  Bluefruit.setTxPower(4);
+  Bluefruit.setName("DM ancs loopback");
+  Bluefruit.setConnectCallback(connect_callback);
+  Bluefruit.setDisconnectCallback(disconnect_callback);
+
+  // Configure and Start Device Information Service
+  bledis.setManufacturer("Drivemode Inc.");
+  bledis.setModel("Drivemode Socket alpha");
+  bledis.begin();
+
+  // Configure DIS client
+  bleClientDis.begin();
+
+  // Configure ANCS client
+  bleancs.begin();
+  bleancs.setNotificationCallback(ancs_loopback_notification_callback);
+  bleancs.setDataCallback(ancs_loopback_data_callback);
+
+  // Configure ANCS Loopback GATT
+  loopbackGattService.begin();
+  
+  loopbackNotificationChr.setProperties(CHR_PROPS_NOTIFY);
+  loopbackNotificationChr.begin();
+
+  loopbackControlPointChr.setProperties(CHR_PROPS_WRITE);
+  loopbackControlPointChr.begin();
+
+  loopbackDataSourceChr.setProperties(CHR_PROPS_NOTIFY);
+  loopbackDataSourceChr.begin();
+  
+  startAdvertise();
+}
+
+void loop () {}
+
+void startAdvertise(void) {
+  // Advertising packet
+  Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
+  Bluefruit.Advertising.addTxPower();
+  Bluefruit.Advertising.addAppearance(BLE_APPEARANCE_UNKNOWN);
+
+  Bluefruit.Advertising.addService(loopbackGattService);
+  
+  // Since there is no room for 'Name' in Advertising packet
+  Bluefruit.ScanResponse.addName();
+  
+  /* Start Advertising
+     - Enable auto advertising if disconnected
+     - Interval:  fast mode = 20 ms, slow mode = 152.5 ms
+     - Timeout for fast mode is 30 seconds
+     - Start(timeout) with timeout = 0 will advertise forever (until connected)
+
+     For recommended advertising interval
+     https://developer.apple.com/library/content/qa/qa1931/_index.html
+  */
+  Bluefruit.Advertising.restartOnDisconnect(true);
+  Bluefruit.Advertising.setInterval(32, 244);    // in unit of 0.625 msu
+  Bluefruit.Advertising.setFastTimeout(30);      // number of seconds in fast mode
+  Bluefruit.Advertising.start();
+}
+
+void connect_callback(uint16_t conn_handle)
+{
+  Serial.println(conn_handle);
+  Serial.println(F("Connected"));
+
+  Serial.print(F("Discovering DIS ... "));
+  if ( bleClientDis.discover(conn_handle) )
+  {
+    Serial.println(F("Discovered"));
+
+    // Read and print Manufacturer string
+    memset(buffer, 0, sizeof(buffer));
+    if ( bleClientDis.getManufacturer(buffer, sizeof(buffer)) )
+    {
+      Serial.print(F("Manufacturer: "));
+      Serial.println(buffer);
+    }
+
+    // Read and print Model Number string
+    memset(buffer, 0, sizeof(buffer));
+    if ( bleClientDis.getModel(buffer, sizeof(buffer)) )
+    {
+      Serial.print(F("Model: "));
+      Serial.println(buffer);
+    }
+
+    Serial.println();
+  }
+
+  discoverANCS(conn_handle);
+}
+
+void discoverANCS(uint16_t conn_handle) {
+  Serial.print(F("Discovering ANCS ... "));
+  if ( bleancs.discover(conn_handle) )
+  {
+    Serial.println(F("Discovered"));
+
+    // ANCS requires pairing to work, it makes sense to request security here as well
+    Serial.print(F("Attempting to PAIR with the iOS device, please press PAIR on your phone ... "));
+    if ( ! Bluefruit.connPaired() ) {
+      if ( Bluefruit.requestPairing() )
+      {
+        Serial.println(F("Done"));
+        Serial.println(F("Enabling notifications"));
+        Serial.println();
+        bleancs.enableNotification();
+      }
+    }
+  }
+}
+
+void disconnect_callback(uint16_t conn_handle, uint8_t reason)
+{
+  (void) reason;
+  Serial.println();
+  Serial.println(F("Disconnected"));
+}
+
+void ancs_loopback_notification_callback(uint8_t* data, uint16_t len)
+{
+  Serial.println("received notification");
+  loopbackNotificationChr.notify(data, len);
+}
+
+void ancsLoopbackWriteCallback(BLECharacteristic& chr, uint8_t* data, uint16_t len, uint16_t offset)
+{
+  Serial.println("writing to Control point");
+  bleancs.requestNotificationData(data, len);
+}
+
+void ancs_loopback_data_callback(uint8_t* data, uint16_t len)
+{
+  Serial.println("reiceved the information requested");
+  loopbackDataSourceChr.notify(data, len);
+}

--- a/libraries/Bluefruit52Lib/examples/Peripheral/ancs_loopback/ancs_loopback.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/ancs_loopback/ancs_loopback.ino
@@ -47,13 +47,11 @@ void setup ()
   Bluefruit.begin();
   // Set max power. Accepted values are: -40, -30, -20, -16, -12, -8, -4, 0, 4
   Bluefruit.setTxPower(4);
-  Bluefruit.setName("DM ancs loopback");
+  Bluefruit.setName("Bluefruit52");
   Bluefruit.setConnectCallback(connect_callback);
   Bluefruit.setDisconnectCallback(disconnect_callback);
 
   // Configure and Start Device Information Service
-  bledis.setManufacturer("Drivemode Inc.");
-  bledis.setModel("Drivemode Socket alpha");
   bledis.begin();
 
   // Configure DIS client

--- a/libraries/Bluefruit52Lib/src/bluefruit.h
+++ b/libraries/Bluefruit52Lib/src/bluefruit.h
@@ -77,6 +77,7 @@
 #include "services/EddyStone.h"
 
 #include "clients/BLEAncs.h"
+#include "clients/BLEAncsLoopback.h"
 #include "clients/BLEClientUart.h"
 #include "clients/BLEClientDis.h"
 #include "clients/BLEClientCts.h"

--- a/libraries/Bluefruit52Lib/src/clients/BLEAncsLoopback.cpp
+++ b/libraries/Bluefruit52Lib/src/clients/BLEAncsLoopback.cpp
@@ -1,0 +1,178 @@
+/**************************************************************************/
+/*!
+    @file     BLEAncs.cpp
+    @author   hathach (tinyusb.org)
+
+    @section LICENSE
+
+    Software License Agreement (BSD License)
+
+    Copyright (c) 2018, Adafruit Industries (adafruit.com)
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holders nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/**************************************************************************/
+
+#include "bluefruit.h"
+
+#define BLE_ANCS_LOOPBACK_TIMEOUT   (5*BLE_GENERIC_TIMEOUT)
+
+#define DEBUG_ANCS_LOOPBACK    1
+
+void bleancs_loopback_notification_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len);
+void bleancs_loopback_data_cb        (BLEClientCharacteristic* chr, uint8_t* data, uint16_t len);
+
+/* ANCS Service        : 7905F431-B5CE-4E99-A40F-4B1E122D00D0
+ * Control Point       : 69D1D8F3-45E1-49A8-9821-9BBDFDAAD9D9
+ * Notification Source : 9FBF120D-6301-42D9-8C58-25E699A21DBD
+ * Data Source         : 22EAC6E9-24D6-4BB5-BE44-B36ACE7C7BFB
+ */
+
+const uint8_t BLEANCS_LOOPBACK_UUID_SERVICE[] =
+{
+    0xD0, 0x00, 0x2D, 0x12, 0x1E, 0x4B, 0x0F, 0xA4,
+    0x99, 0x4E, 0xCE, 0xB5, 0x31, 0xF4, 0x05, 0x79
+};
+
+const uint8_t BLEANCS_LOOPBACK_UUID_CHR_CONTROL[] =
+{
+    0xD9, 0xD9, 0xAA, 0xFD, 0xBD, 0x9B, 0x21, 0x98, 
+    0xA8, 0x49, 0xE1, 0x45, 0xF3, 0xD8, 0xD1, 0x69
+};
+
+const uint8_t BLEANCS_LOOPBACK_UUID_CHR_NOTIFICATION[]
+{
+    0xBD, 0x1D, 0xA2, 0x99, 0xE6, 0x25, 0x58, 0x8C,
+    0xD9, 0x42, 0x01, 0x63, 0x0D, 0x12, 0xBF, 0x9F
+};
+
+const uint8_t BLEANCS_LOOPBACK_UUID_CHR_DATA[] =
+{
+    0xFB, 0x7B, 0x7C, 0xCE, 0x6A, 0xB3, 0x44, 0xBE,
+    0xB5, 0x4B, 0xD6, 0x24, 0xE9, 0xC6, 0xEA, 0x22
+};
+
+BLEAncsLoopback::BLEAncsLoopback(void)
+  : BLEClientService(BLEANCS_LOOPBACK_UUID_SERVICE), _control(BLEANCS_LOOPBACK_UUID_CHR_CONTROL),
+    _notification(BLEANCS_LOOPBACK_UUID_CHR_NOTIFICATION), _data(BLEANCS_LOOPBACK_UUID_CHR_DATA)
+{
+  _notif_cb = NULL;
+  _data_cb = NULL;
+}
+
+bool BLEAncsLoopback::begin(void)
+{
+  // Invoke base class begin()
+  BLEClientService::begin();
+
+  _control.begin();
+  _notification.begin();
+  _data.begin();
+
+  _notification.setNotifyCallback(bleancs_loopback_notification_cb);
+  _data.setNotifyCallback(bleancs_loopback_data_cb);
+
+  return true;
+}
+
+bool BLEAncsLoopback::discover(uint16_t conn_handle)
+{
+  // Call BLECentralService discover
+  VERIFY( BLEClientService::discover(conn_handle) );
+  _conn_hdl = BLE_CONN_HANDLE_INVALID; // make as invalid until we found all chars
+
+  // Discover characteristics
+  BLEClientCharacteristic* chr_arr[] = { &_control, &_notification, &_data };
+
+  VERIFY( 3 == Bluefruit.Discovery.discoverCharacteristic(conn_handle, chr_arr, 3) );
+
+  _conn_hdl = conn_handle;
+  return true;
+}
+
+void BLEAncsLoopback::setNotificationCallback(notification_callback_t fp)
+{
+  _notif_cb = fp;
+}
+
+void BLEAncsLoopback::setDataCallback(data_callback_t fp)
+{
+  _data_cb = fp;
+}
+
+bool BLEAncsLoopback::enableNotification(void)
+{
+  // enable both Notification & Data Source
+  VERIFY ( _data.enableNotify() );
+  VERIFY ( _notification.enableNotify() );
+
+  return true;
+}
+
+bool BLEAncsLoopback::disableNotification(void)
+{
+  _notification.disableNotify();
+  _data.disableNotify();
+
+  return true;
+}
+
+void BLEAncsLoopback::requestNotificationData(uint8_t* data, uint16_t len)
+{
+  #if DEBUG_ANCS
+    PRINT_BUFFER(data, len);
+  #endif
+
+  _control.write_resp(data, len);
+}
+
+void BLEAncsLoopback::_handleNotification(uint8_t* data, uint16_t len)
+{
+  if ( len != 8  ) return;
+  if ( _notif_cb ) _notif_cb(data, len);
+}
+
+void BLEAncsLoopback::_handleData(uint8_t* data, uint16_t len)
+{
+  #if DEBUG_ANCS
+    PRINT_BUFFER(data, len);
+  #endif
+
+  if ( _data_cb ) _data_cb(data, len);
+}
+
+/*------------------------------------------------------------------*/
+/* Callback
+ *------------------------------------------------------------------*/
+void bleancs_loopback_notification_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len)
+{
+  BLEAncsLoopback& svc = (BLEAncsLoopback&) chr->parentService();
+  svc._handleNotification(data, len);
+}
+
+void bleancs_loopback_data_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len)
+{
+  BLEAncsLoopback& svc = (BLEAncsLoopback&) chr->parentService();
+  svc._handleData(data, len);
+}

--- a/libraries/Bluefruit52Lib/src/clients/BLEAncsLoopback.cpp
+++ b/libraries/Bluefruit52Lib/src/clients/BLEAncsLoopback.cpp
@@ -1,7 +1,7 @@
 /**************************************************************************/
 /*!
-    @file     BLEAncs.cpp
-    @author   hathach (tinyusb.org)
+    @file     BLEAncsLoopback.cpp
+    @author   ferbass (ferbass.com)
 
     @section LICENSE
 

--- a/libraries/Bluefruit52Lib/src/clients/BLEAncsLoopback.h
+++ b/libraries/Bluefruit52Lib/src/clients/BLEAncsLoopback.h
@@ -1,0 +1,84 @@
+/**************************************************************************/
+/*!
+    @file     BLEAncs.h
+    @author   hathach (tinyusb.org)
+
+    @section LICENSE
+
+    Software License Agreement (BSD License)
+
+    Copyright (c) 2018, Adafruit Industries (adafruit.com)
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holders nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/**************************************************************************/
+#ifndef BLEANCSLOOPBACK_H_
+#define BLEANCSLOOPBACK_H_
+
+#include "../BLEClientCharacteristic.h"
+#include "bluefruit_common.h"
+
+#include "BLEClientService.h"
+
+extern const uint8_t BLEANCS_UUID_SERVICE[];
+extern const uint8_t BLEANCS_UUID_CHR_CONTROL[];
+extern const uint8_t BLEANCS_UUID_CHR_NOTIFICATION[];
+extern const uint8_t BLEANCS_UUID_CHR_DATA[];
+
+class BLEAncsLoopback : public BLEClientService
+{
+  public:
+    typedef void (*notification_callback_t) (uint8_t* data, uint16_t len);
+    typedef void (*data_callback_t) (uint8_t* data, uint16_t len);
+
+    BLEAncsLoopback(void);
+
+    virtual bool  begin(void);
+    virtual bool  discover(uint16_t conn_handle);
+
+    void setNotificationCallback(notification_callback_t fp);
+    void setDataCallback(data_callback_t fp);
+
+    void requestNotificationData(uint8_t* data, uint16_t len);
+    
+    bool enableNotification(void);
+    bool disableNotification(void);
+
+  private:
+    BLEClientCharacteristic _control;
+    BLEClientCharacteristic _notification;
+    BLEClientCharacteristic _data;
+
+    notification_callback_t _notif_cb;
+    data_callback_t _data_cb;
+
+    void _handleNotification(uint8_t* data, uint16_t len);
+    void _handleData(uint8_t* data, uint16_t len);
+
+    friend void bleancs_loopback_notification_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len);
+    friend void bleancs_loopback_data_cb        (BLEClientCharacteristic* chr, uint8_t* data, uint16_t len);
+};
+
+
+#endif /* BLEANCSLOOPBACK_H_ */

--- a/libraries/Bluefruit52Lib/src/clients/BLEAncsLoopback.h
+++ b/libraries/Bluefruit52Lib/src/clients/BLEAncsLoopback.h
@@ -1,7 +1,7 @@
 /**************************************************************************/
 /*!
-    @file     BLEAncs.h
-    @author   hathach (tinyusb.org)
+    @file     BLEAncsLoopback.h
+    @author   ferbass (ferbass.com)
 
     @section LICENSE
 


### PR DESCRIPTION
# Propose
- ANCS Loopback will create a mirror characteristics of ANCS that can be use to connect to a non-hardware project and exchange the ANCS data through this characteristics. That way the non-hardware project like Apps can handle the raw ANCS that on their side and request the info that they need just sending the request to the ANCS using the Loopback