### PR TITLE
Fix #250 -- wrong values for g_ADigitalPinMap

### DIFF
--- a/variants/feather_nrf52840_express/variant.cpp
+++ b/variants/feather_nrf52840_express/variant.cpp
@@ -28,47 +28,74 @@
 
 const uint32_t g_ADigitalPinMap[] =
 {
-  25,  // D0 is UART TX on P0.25
-  24,  // D1 is UART RX on P0.24 
-  10,  // D2 is on P0.10
-  47,  // D3 is LED1 on P1.15
-  42,  // D4 is LED2 on P1.10
-  40,  // D5 on P1.08
-  7,   // D6 on P0.07 
-  34,  // D7 is Button on P1.02
-  16,  // D8 is NeoPixel on P0.16
-  26,  // D9 on P0.26
-  27,  // D10 on P0.27 
-  6,   // D11 on P.06 
-  8,   // D12 on P0.08
-  41,  // D13 on P1.09 
+  // D0 .. D13
+  25,  // D0  is P0.25 (UART TX)
+  24,  // D1  is P0.24 (UART RX 
+  10,  // D2  is P0.10 (NFC2)
+  47,  // D3  is P1.15 (LED1)
+  42,  // D4  is P1.10 (LED2)
+  40,  // D5  is P1.08
+   7,  // D6  is P0.07
+  34,  // D7  is P1.02 (Button)
+  16,  // D8  is P0.16 (NeoPixel)
+  26,  // D9  is P0.26
+  27,  // D10 is P0.27
+   6,  // D11 is P0.06
+   8,  // D12 is P0.08
+  41,  // D13 is P1.09
 
-  4,   // D14 is A0 on P0.04
-  5,   // D15 is A1 on P0.05
-  30,  // D16 is A2 on P0.30
-  28,  // D17 is A3 on P0.28
-  2,   // D18 is A4 on P0.02
-  3,   // D19 is A5 on P0.03
-  29,  // D20 is A6 (Battery) on P0.29
-  31,  // D21 is A7 (ARef) on P0.31
+  // D14 .. D21 (aka A0 .. A7)
+   4,  // D14 is P0.04 (A0)
+   5,  // D15 is P0.05 (A1)
+  30,  // D16 is P0.30 (A2)
+  28,  // D17 is P0.28 (A3)
+   2,  // D18 is P0.02 (A4)
+   3,  // D19 is P0.03 (A5)
+  29,  // D20 is P0.29 (A6, Battery)
+  31,  // D21 is P0.31 (A7, ARef)
 
-  12,  // D22 is SDA on P0.12
-  11,  // D23 is SCL on P0.11
+  // D22 .. D23 (aka I2C pins)
+  12,  // D22 is P0.12 (SDA)
+  11,  // D23 is P0.11 (SCL)
 
-  15,  // D24 is SPI MISO on P0.15 
-  13,  // D25 is SPI MOSI on P0.13 
-  14,  // D26 is SPI SCK on P0.14 
+  // D24 .. D26 (aka SPI pins)
+  15,  // D24 is P0.15 (SPI MISO)
+  13,  // D25 is P0.13 (SPI MOSI)
+  14,  // D26 is P0.14 (SPI SCK )
 
-  19,  // D27 is QSPI CLK on P0.19
-  20,  // D28 is QSPI CS on P0.20
-  17,  // D29 is QSPI Data 0 on P0.17
-  22,  // D30 is QSPI Data 1 on P0.22
-  23,  // D31 is QSPI Data 2 on P0.23
-  21,  // D32 is QSPI Data 3 on P0.21
+  // QSPI pins (not exposed via any header / test point)
+  19,  // D27 is P0.19 (QSPI CLK)
+  20,  // D28 is P0.20 (QSPI CS)
+  17,  // D29 is P0.17 (QSPI Data 0)
+  22,  // D30 is P0.22 (QSPI Data 1)
+  23,  // D31 is P0.23 (QSPI Data 2)
+  21,  // D32 is P0.21 (QSPI Data 3)
 
-  // P1
-  33, 34, 35, 36, 37, 38, 39,
-  40, 41, 42, 43, 44, 45, 46, 47
+  // The remaining NFC pin
+   9,  // D33 is P0.09 (NFC1, exposed only via test point on bottom of board)
+
+  // Thus, there are 34 defined pins
+
+  // The remaining pins are not usable:
+  //
+  //
+  // The following pins were never listed as they were considered unusable
+  //  0,      // P0.00 is XL1   (attached to 32.768kHz crystal)
+  //  1,      // P0.01 is XL2   (attached to 32.768kHz crystal)
+  // 18,      // P0.18 is RESET (attached to switch)
+  // 32,      // P0.00 is SWO   (attached to debug header)
+  // 
+  // The remaining pins are not connected (per schematic)
+  // 33,      // P1.01 is not connected per schematic
+  // 35,      // P1.03 is not connected per schematic
+  // 36,      // P1.04 is not connected per schematic
+  // 37,      // P1.05 is not connected per schematic
+  // 38,      // P1.06 is not connected per schematic
+  // 39,      // P1.07 is not connected per schematic
+  // 43,      // P1.11 is not connected per schematic
+  // 44,      // P1.12 is not connected per schematic
+  // 45,      // P1.13 is not connected per schematic
+  // 46,      // P1.14 is not connected per schematic
 };
 
 void initVariant()

--- a/variants/feather_nrf52840_express/variant.cpp
+++ b/variants/feather_nrf52840_express/variant.cpp
@@ -83,7 +83,7 @@ const uint32_t g_ADigitalPinMap[] =
   //  0,      // P0.00 is XL1   (attached to 32.768kHz crystal)
   //  1,      // P0.01 is XL2   (attached to 32.768kHz crystal)
   // 18,      // P0.18 is RESET (attached to switch)
-  // 32,      // P0.00 is SWO   (attached to debug header)
+  // 32,      // P1.00 is SWO   (attached to debug header)
   // 
   // The remaining pins are not connected (per schematic)
   // 33,      // P1.01 is not connected per schematic

--- a/variants/feather_nrf52840_express/variant.h
+++ b/variants/feather_nrf52840_express/variant.h
@@ -37,9 +37,9 @@ extern "C"
 #endif // __cplusplus
 
 // Number of pins defined in PinDescription array
-#define PINS_COUNT           (48)
-#define NUM_DIGITAL_PINS     (48)
-#define NUM_ANALOG_INPUTS    (6)
+#define PINS_COUNT           (34)
+#define NUM_DIGITAL_PINS     (34)
+#define NUM_ANALOG_INPUTS    (6) // A6 is used for battery, A7 is analog reference
 #define NUM_ANALOG_OUTPUTS   (0)
 
 // LEDs
@@ -88,8 +88,8 @@ static const uint8_t A7  = PIN_A7 ;
 // Other pins
 #define PIN_AREF           (PIN_A7)
 #define PIN_DFU            (7)
-#define PIN_NFC1           (2)
-#define PIN_NFC2           (51)
+#define PIN_NFC1           (33)
+#define PIN_NFC2           (2)
 
 static const uint8_t AREF = PIN_AREF;
 


### PR DESCRIPTION
This fixes the issues identified in #250.

* Update definition of `PINS_COUNT` and `NUM_DIGITAL_PINS` to reflect mappable pin count for this board (34).
* Update `g_ADigitalPinMap` to define only 34 pins.
* Add comments to `g_ADigitalPinMap`, describing the non-mapped 14 pins, and why they are not listed.
