### PR TITLE
Extend SoftwareTimer with option to make it non-repeating, add reset function & ISR-safe functions.

### DIFF
--- a/cores/nRF5/utility/SoftwareTimer.h
+++ b/cores/nRF5/utility/SoftwareTimer.h
@@ -52,6 +52,11 @@ class SoftwareTimer
       _handle = xTimerCreate(NULL, ms2tick(ms), true, NULL, callback);
     }
 
+    void begin(uint32_t ms, TimerCallbackFunction_t callback, bool repeating)
+    {
+      _handle = xTimerCreate(NULL, ms2tick(ms), repeating, NULL, callback);
+    }
+
     TimerHandle_t getHandle(void)
     {
       return _handle;
@@ -59,6 +64,17 @@ class SoftwareTimer
 
     void start(void) { xTimerStart(_handle, 0); }
     void stop (void) { xTimerStop (_handle, 0); }
+    void reset(void) { xTimerReset(_handle, 0); }
+
+    BaseType_t startFromISR(BaseType_t* pxHigherPriorityTaskWoken) {
+      return xTimerStartFromISR(_handle, pxHigherPriorityTaskWoken);
+    }
+    BaseType_t stopFromISR(BaseType_t* pxHigherPriorityTaskWoken) {
+      return xTimerStopFromISR (_handle, pxHigherPriorityTaskWoken);
+    }
+    BaseType_t resetFromISR(BaseType_t* pxHigherPriorityTaskWoken) {
+      return xTimerResetFromISR(_handle, pxHigherPriorityTaskWoken);
+    }
 
     void setPeriod(uint32_t ms)
     {

--- a/cores/nRF5/utility/SoftwareTimer.h
+++ b/cores/nRF5/utility/SoftwareTimer.h
@@ -47,12 +47,7 @@ class SoftwareTimer
     SoftwareTimer()          { _handle = NULL; }
     virtual ~SoftwareTimer() { if(_handle != NULL) xTimerDelete(_handle, 0); }
 
-    void begin(uint32_t ms, TimerCallbackFunction_t callback)
-    {
-      _handle = xTimerCreate(NULL, ms2tick(ms), true, NULL, callback);
-    }
-
-    void begin(uint32_t ms, TimerCallbackFunction_t callback, bool repeating)
+    void begin(uint32_t ms, TimerCallbackFunction_t callback, bool repeating = true)
     {
       _handle = xTimerCreate(NULL, ms2tick(ms), repeating, NULL, callback);
     }

--- a/cores/nRF5/utility/SoftwareTimer.h
+++ b/cores/nRF5/utility/SoftwareTimer.h
@@ -61,14 +61,25 @@ class SoftwareTimer
     void stop (void) { xTimerStop (_handle, 0); }
     void reset(void) { xTimerReset(_handle, 0); }
 
-    BaseType_t startFromISR(BaseType_t* pxHigherPriorityTaskWoken = NULL) {
-      return xTimerStartFromISR(_handle, pxHigherPriorityTaskWoken);
+    bool startFromISR(void) {
+      BaseType_t ret, xHigherPriorityTaskWoken = pdFALSE;
+      ret = xTimerStartFromISR(_handle, &xHigherPriorityTaskWoken);
+      portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+      return (ret == pdPASS);
     }
-    BaseType_t stopFromISR(BaseType_t* pxHigherPriorityTaskWoken = NULL) {
-      return xTimerStopFromISR (_handle, pxHigherPriorityTaskWoken);
+
+    bool stopFromISR(void) {
+      BaseType_t ret, xHigherPriorityTaskWoken = pdFALSE;
+      ret = xTimerStopFromISR(_handle, &xHigherPriorityTaskWoken);
+      portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+      return (ret == pdPASS);
     }
-    BaseType_t resetFromISR(BaseType_t* pxHigherPriorityTaskWoken = NULL) {
-      return xTimerResetFromISR(_handle, pxHigherPriorityTaskWoken);
+
+    bool resetFromISR(void) {
+      BaseType_t ret, xHigherPriorityTaskWoken = pdFALSE;
+      ret = xTimerResetFromISR(_handle, &xHigherPriorityTaskWoken);
+      portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+      return (ret == pdPASS);
     }
 
     void setPeriod(uint32_t ms)

--- a/cores/nRF5/utility/SoftwareTimer.h
+++ b/cores/nRF5/utility/SoftwareTimer.h
@@ -61,13 +61,13 @@ class SoftwareTimer
     void stop (void) { xTimerStop (_handle, 0); }
     void reset(void) { xTimerReset(_handle, 0); }
 
-    BaseType_t startFromISR(BaseType_t* pxHigherPriorityTaskWoken) {
+    BaseType_t startFromISR(BaseType_t* pxHigherPriorityTaskWoken = NULL) {
       return xTimerStartFromISR(_handle, pxHigherPriorityTaskWoken);
     }
-    BaseType_t stopFromISR(BaseType_t* pxHigherPriorityTaskWoken) {
+    BaseType_t stopFromISR(BaseType_t* pxHigherPriorityTaskWoken = NULL) {
       return xTimerStopFromISR (_handle, pxHigherPriorityTaskWoken);
     }
-    BaseType_t resetFromISR(BaseType_t* pxHigherPriorityTaskWoken) {
+    BaseType_t resetFromISR(BaseType_t* pxHigherPriorityTaskWoken = NULL) {
       return xTimerResetFromISR(_handle, pxHigherPriorityTaskWoken);
     }
 


### PR DESCRIPTION
The SoftwareTimer provided by the library is missing a function for resetting it.

Also, I want to reset this timer from an ISR attached by attachInterrupt. Based on the documentation at https://www.freertos.org/FreeRTOS-timers-xTimerResetFromISR.html, I figured it was necessary to use the ISR-safe functions, so there's ISR-safe equivalents included. I'm not quite certain about their name, though; I used ISR because that was what was in my head at the time but it might be more appropriate to name them more in line with Arduino-style "attachInterrupt" thus becoming "resetFromInterrupt" etc.

Finally, the timer I want must be non-repeating, only getting started when an interrupt tells it to start. So I added a begin()-function that adds a boolean to its signature to specify whether the timer repeats if it ticks over or suspends.

See
https://github.com/MacGyverNL/bluepedal/blob/02213ee9dcc495ccdc47f572892f7388aac09a55/bluepedal/bluepedal.ino#L190
and
https://github.com/MacGyverNL/bluepedal/blob/02213ee9dcc495ccdc47f572892f7388aac09a55/bluepedal/bluepedal.ino#L281
for context of how I'm using them to implement a loopless HID.