### PR TITLE
Adding corrected spelling

### DIFF
--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -580,12 +580,22 @@ void AdafruitBluefruit::setConnLedInterval(uint32_t ms)
   if ( !active ) xTimerStop(_led_blink_th, 0);
 }
 
-bool AdafruitBluefruit::setApperance(uint16_t appear)
+bool AdafruitBluefruit::setApperance(uin16_t appear)
+{
+   setAppearance(appear);
+}
+
+bool AdafruitBluefruit::setAppearance(uint16_t appear)
 {
   return ERROR_NONE == sd_ble_gap_appearance_set(appear);
 }
 
-uint16_t AdafruitBluefruit::getApperance(void)
+bool AdafruitBluefruit::getApperance(void)
+{
+  getAppearance(void);
+}
+
+uint16_t AdafruitBluefruit::getAppearance(void)
 {
   uint16_t appear = 0;
   (void) sd_ble_gap_appearance_get(&appear);

--- a/libraries/Bluefruit52Lib/src/bluefruit.h
+++ b/libraries/Bluefruit52Lib/src/bluefruit.h
@@ -154,7 +154,9 @@ class AdafruitBluefruit
     int8_t   getTxPower         (void);
 
     bool     setApperance       (uint16_t appear);
+    bool     setAppearance      (uint16_t appear);
     uint16_t getApperance       (void);
+    uint16_t getAppearance      (void);
 
     ble_gap_sec_params_t getSecureParam(void)
     {


### PR DESCRIPTION
Adding functions with corrected spelling:

setApperance -> setAppearance
getApperance -> setAppearance

Not removing incorrect spelling for backwards-compatibility