### PR TITLE
Corrected location of consumer usage codes

### DIFF
--- a/libraries/Bluefruit52Lib/examples/Peripheral/hid_camerashutter/hid_camerashutter.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/hid_camerashutter/hid_camerashutter.ino
@@ -111,7 +111,7 @@ void loop()
       digitalWrite(LED_RED, 1);
 
       // Send the 'volume down' key press
-      // Check BLEHidGeneric.h for a list of valid consumer usage codes
+      // Check hid.h for a list of valid consumer usage codes
       blehid.consumerKeyPress(HID_USAGE_CONSUMER_VOLUME_DECREMENT);
 
       // Delay a bit between reports


### PR DESCRIPTION
Consumer usage codes are in Adafruit_nRF52_Arduino/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/class/hid/hid.h (or at least that is where I found them) - not BLEHidGeneric.h