### PR TITLE
Added response to read authorize requests

### DIFF
--- a/cores/nRF5/nordic/softdevice/s132_nrf52_6.1.1_API/include/ble_gap.h
+++ b/cores/nRF5/nordic/softdevice/s132_nrf52_6.1.1_API/include/ble_gap.h
@@ -594,6 +594,9 @@ enum BLE_GAP_TX_POWER_ROLES
 /**@brief Maximum amount of addresses in the whitelist. */
 #define BLE_GAP_WHITELIST_ADDR_MAX_COUNT (8)
 
+/**@brief Maximum amount of IRKs in a whitelist. */
+#define BLE_GAP_WHITELIST_IRK_MAX_COUNT (8)
+
 
 /**@brief Maximum amount of identities in the device identities list. */
 #define BLE_GAP_DEVICE_IDENTITIES_MAX_COUNT (8)
@@ -693,7 +696,6 @@ typedef struct
   uint8_t addr[BLE_GAP_ADDR_LEN]; /**< 48-bit address, LSB format.
                                        @ref addr is not used if @ref addr_type is @ref BLE_GAP_ADDR_TYPE_ANONYMOUS. */
 } ble_gap_addr_t;
-
 
 /**@brief GAP connection parameters.
  *

--- a/libraries/Bluefruit52Lib/src/BLEAdvertising.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEAdvertising.cpp
@@ -396,6 +396,18 @@ bool BLEAdvertising::stop(void)
   return true;
 }
 
+bool BLEAdvertising::setWhitelist(ble_gap_addr_t const * const * addrs, uint8_t len) {
+  VERIFY_STATUS( sd_ble_gap_whitelist_set(addrs, len) );
+
+  return true;
+}
+
+bool BLEAdvertising::clearWhitelist() {
+  VERIFY_STATUS( sd_ble_gap_whitelist_set(NULL, 0) );
+
+  return true;
+}
+
 
 void BLEAdvertising::_eventHandler(ble_evt_t* evt)
 {

--- a/libraries/Bluefruit52Lib/src/BLEAdvertising.h
+++ b/libraries/Bluefruit52Lib/src/BLEAdvertising.h
@@ -129,6 +129,9 @@ public:
   void setInterval  (uint16_t fast, uint16_t slow);
   void setIntervalMS(uint16_t fast, uint16_t slow);
 
+  bool setWhitelist(ble_gap_addr_t const * const * addrs, uint8_t len);
+  bool clearWhitelist();
+
   uint16_t getInterval(void);
 
   bool setBeacon(BLEBeacon& beacon);

--- a/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
+++ b/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
@@ -370,7 +370,7 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
           _rd_authorize_cb(conn_hdl, this, rd_req);
         }
 
-        if (Bluefruit.connPaired()) {
+        if (Bluefruit.connPaired(conn_hdl)) {
           ble_gatts_rw_authorize_reply_params_t reply = { .type = BLE_GATTS_AUTHORIZE_TYPE_READ };
           sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
         }
@@ -428,7 +428,7 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
               _long_wr.count = max16(_long_wr.count, wr_req->offset + wr_req->len);
             }
 
-            if (Bluefruit.connPaired(conn_hndl))
+            if (Bluefruit.connPaired(conn_hdl))
               sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
           }
           break;
@@ -440,7 +440,7 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
               ble_gatts_rw_authorize_reply_params_t reply = { .type = BLE_GATTS_AUTHORIZE_TYPE_WRITE };
               reply.params.write.gatt_status = BLE_GATT_STATUS_SUCCESS;
 
-              if (Bluefruit.connPaired(conn_hndl))
+              if (Bluefruit.connPaired(conn_hdl))
                 sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
 
               // Long write complete, call write callback if set

--- a/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
+++ b/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
@@ -369,6 +369,11 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
         {
           _rd_authorize_cb(conn_hdl, this, rd_req);
         }
+
+        if (Bluefruit.connPaired()) {
+          ble_gatts_rw_authorize_reply_params_t reply = { .type = BLE_GATTS_AUTHORIZE_TYPE_READ };
+          sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
+        }
       }
 
       // Write Authorization and Long Write sequence handling
@@ -390,6 +395,7 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
                 _wr_authorize_cb(conn_hdl, this, wr_req);
               }
             }
+
           break;
 
           case BLE_GATTS_OP_PREP_WRITE_REQ:
@@ -422,7 +428,8 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
               _long_wr.count = max16(_long_wr.count, wr_req->offset + wr_req->len);
             }
 
-            sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
+            if (Bluefruit.connPaired())
+              sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
           }
           break;
 
@@ -433,7 +440,8 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
               ble_gatts_rw_authorize_reply_params_t reply = { .type = BLE_GATTS_AUTHORIZE_TYPE_WRITE };
               reply.params.write.gatt_status = BLE_GATT_STATUS_SUCCESS;
 
-              sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
+              if (Bluefruit.connPaired())
+                sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
 
               // Long write complete, call write callback if set
               if (_wr_cb)

--- a/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
+++ b/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
@@ -428,7 +428,7 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
               _long_wr.count = max16(_long_wr.count, wr_req->offset + wr_req->len);
             }
 
-            if (Bluefruit.connPaired())
+            if (Bluefruit.connPaired(conn_hndl))
               sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
           }
           break;
@@ -440,7 +440,7 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
               ble_gatts_rw_authorize_reply_params_t reply = { .type = BLE_GATTS_AUTHORIZE_TYPE_WRITE };
               reply.params.write.gatt_status = BLE_GATT_STATUS_SUCCESS;
 
-              if (Bluefruit.connPaired())
+              if (Bluefruit.connPaired(conn_hndl))
                 sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
 
               // Long write complete, call write callback if set

--- a/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
+++ b/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
@@ -369,17 +369,11 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
         {
           _rd_authorize_cb(conn_hdl, this, rd_req);
         }
-<<<<<<< HEAD
 
         if (Bluefruit.connPaired()) {
           ble_gatts_rw_authorize_reply_params_t reply = { .type = BLE_GATTS_AUTHORIZE_TYPE_READ };
           sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
         }
-=======
-          
-        ble_gatts_rw_authorize_reply_params_t reply = { .type = BLE_GATTS_AUTHORIZE_TYPE_READ };
-        sd_ble_gatts_rw_authorize_reply(conn_hdl, &reply);
->>>>>>> bcbb4fce7abbccb279c28fc154b4c9731684f75e
       }
 
       // Write Authorization and Long Write sequence handling

--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -635,9 +635,9 @@ uint16_t AdafruitBluefruit::connHandle(void)
   return _conn_hdl;
 }
 
-bool AdafruitBluefruit::connPaired(void)
+bool AdafruitBluefruit::connPaired(uint16_t conn_hdl)
 {
-  BLEConnection* conn = Bluefruit.Connection(_conn_hdl);
+  BLEConnection* conn = Bluefruit.Connection(conn_hdl);
   return conn && conn->paired();
 }
 

--- a/libraries/Bluefruit52Lib/src/bluefruit.h
+++ b/libraries/Bluefruit52Lib/src/bluefruit.h
@@ -173,7 +173,7 @@ class AdafruitBluefruit
     bool     connected         (uint16_t conn_hdl);
 
     uint16_t connHandle        (void);
-    bool     connPaired        (void);
+    bool     connPaired        (uint16_t conn_hdl);
 
     // Alias to BLEConnection API()
     bool     disconnect        (uint16_t conn_hdl);


### PR DESCRIPTION
If you add a `setReadAuthorizeCallback` to a BLECharacteristic, it hangs because there is no response. This PR adds a response to read authorize requests.