### PR TITLE
Add availableForWrite method to Serial.

### DIFF
--- a/cores/nRF5/Adafruit_TinyUSB_Core/Adafruit_USBD_CDC.cpp
+++ b/cores/nRF5/Adafruit_TinyUSB_Core/Adafruit_USBD_CDC.cpp
@@ -125,6 +125,11 @@ size_t Adafruit_USBD_CDC::write(const uint8_t *buffer, size_t size)
   return size - remain;
 }
 
+size_t Adafruit_USBD_CDC::availableForWrite(void)
+{
+  return tud_cdc_availableForWrite();
+}
+
 extern "C"
 {
 

--- a/cores/nRF5/Adafruit_TinyUSB_Core/Adafruit_USBD_CDC.cpp
+++ b/cores/nRF5/Adafruit_TinyUSB_Core/Adafruit_USBD_CDC.cpp
@@ -127,7 +127,7 @@ size_t Adafruit_USBD_CDC::write(const uint8_t *buffer, size_t size)
 
 size_t Adafruit_USBD_CDC::availableForWrite(void)
 {
-  return tud_cdc_availableForWrite();
+  return tud_cdc_write_available();
 }
 
 extern "C"

--- a/cores/nRF5/Adafruit_TinyUSB_Core/Adafruit_USBD_CDC.h
+++ b/cores/nRF5/Adafruit_TinyUSB_Core/Adafruit_USBD_CDC.h
@@ -50,6 +50,7 @@ public:
 	size_t write(const char *buffer, size_t size) {
 	  return write((const uint8_t *)buffer, size);
 	}
+        size_t availableForWrite(void);
 	operator bool();
 };
 

--- a/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/class/cdc/cdc_device.c
+++ b/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/class/cdc/cdc_device.c
@@ -190,9 +190,9 @@ bool tud_cdc_n_write_flush (uint8_t itf)
   return true;
 }
 
-uint32_t tud_cdc_n_availableForWrite (uint8_t itf)
+uint32_t tud_cdc_n_write_available (uint8_t itf)
 {
-  return CFG_TUD_CDC_TX_BUFSIZE - tu_fifo_count(&_cdcd_itf[itf].tx_ff);
+  return tu_fifo_remaining(&_cdcd_itf[itf].tx_ff);
 }
 
 

--- a/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/class/cdc/cdc_device.c
+++ b/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/class/cdc/cdc_device.c
@@ -190,6 +190,11 @@ bool tud_cdc_n_write_flush (uint8_t itf)
   return true;
 }
 
+uint32_t tud_cdc_n_availableForWrite (uint8_t itf)
+{
+  return CFG_TUD_CDC_TX_BUFSIZE - tu_fifo_count(&_cdcd_itf[itf].tx_ff);
+}
+
 
 //--------------------------------------------------------------------+
 // USBD Driver API

--- a/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/class/cdc/cdc_device.h
+++ b/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/class/cdc/cdc_device.h
@@ -66,7 +66,7 @@ uint32_t    tud_cdc_n_write_char      (uint8_t itf, char ch);
 uint32_t    tud_cdc_n_write           (uint8_t itf, void const* buffer, uint32_t bufsize);
 uint32_t    tud_cdc_n_write_str       (uint8_t itf, char const* str);
 bool        tud_cdc_n_write_flush     (uint8_t itf);
-uint32_t    tud_cdc_n_availableForWrite (uint8_t itf);
+uint32_t    tud_cdc_n_write_available (uint8_t itf);
 
 //--------------------------------------------------------------------+
 // Application API (Interface0)
@@ -86,7 +86,7 @@ static inline uint32_t    tud_cdc_write_char      (char ch);
 static inline uint32_t    tud_cdc_write           (void const* buffer, uint32_t bufsize);
 static inline uint32_t    tud_cdc_write_str       (char const* str);
 static inline bool        tud_cdc_write_flush     (void);
-static inline uint32_t    tud_cdc_availableForWrite(void);
+static inline uint32_t    tud_cdc_write_available (void);
 
 //--------------------------------------------------------------------+
 // Application Callback API (weak is optional)
@@ -172,9 +172,9 @@ static inline bool tud_cdc_write_flush (void)
   return tud_cdc_n_write_flush(0);
 }
 
-static inline uint32_t tud_cdc_availableForWrite(void)
+static inline uint32_t tud_cdc_write_available(void)
 {
-  return tud_cdc_n_availableForWrite(0);
+  return tud_cdc_n_write_available(0);
 }
 
 /** @} */

--- a/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/class/cdc/cdc_device.h
+++ b/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/class/cdc/cdc_device.h
@@ -66,6 +66,7 @@ uint32_t    tud_cdc_n_write_char      (uint8_t itf, char ch);
 uint32_t    tud_cdc_n_write           (uint8_t itf, void const* buffer, uint32_t bufsize);
 uint32_t    tud_cdc_n_write_str       (uint8_t itf, char const* str);
 bool        tud_cdc_n_write_flush     (uint8_t itf);
+uint32_t    tud_cdc_n_availableForWrite (uint8_t itf);
 
 //--------------------------------------------------------------------+
 // Application API (Interface0)
@@ -85,6 +86,7 @@ static inline uint32_t    tud_cdc_write_char      (char ch);
 static inline uint32_t    tud_cdc_write           (void const* buffer, uint32_t bufsize);
 static inline uint32_t    tud_cdc_write_str       (char const* str);
 static inline bool        tud_cdc_write_flush     (void);
+static inline uint32_t    tud_cdc_availableForWrite(void);
 
 //--------------------------------------------------------------------+
 // Application Callback API (weak is optional)
@@ -168,6 +170,11 @@ static inline uint32_t tud_cdc_write_str (char const* str)
 static inline bool tud_cdc_write_flush (void)
 {
   return tud_cdc_n_write_flush(0);
+}
+
+static inline uint32_t tud_cdc_availableForWrite(void)
+{
+  return tud_cdc_n_availableForWrite(0);
 }
 
 /** @} */


### PR DESCRIPTION
Add availableForWrite method to Serial
Compatible with the standard Arduino API. This will apply cleanly on top of the fix_serial patch.