### PR TITLE
Fix multiple warnings when building.

### DIFF
--- a/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/device/usbd.h
+++ b/cores/nRF5/Adafruit_TinyUSB_Core/tinyusb/src/device/usbd.h
@@ -166,6 +166,8 @@ TU_ATTR_WEAK bool tud_vendor_control_complete_cb(uint8_t rhport, tusb_control_re
 
 // CDC Descriptor Template
 // Interface number, string index, EP notification address and size, EP data address (out, in) and size.
+// NOTE: This returns an list of byte (uint_8) values
+// NOTE: Unwritten & unverified assumption: _itfnum is in range [0..254] (else overflows below adding 1)
 #define TUD_CDC_DESCRIPTOR(_itfnum, _stridx, _ep_notif, _ep_notif_size, _epout, _epin, _epsize) \
   /* Interface Associate */\
   8, TUSB_DESC_INTERFACE_ASSOCIATION, _itfnum, 2, TUSB_CLASS_CDC, CDC_COMM_SUBCLASS_ABSTRACT_CONTROL_MODEL, CDC_COMM_PROTOCOL_ATCOMMAND, 0,\
@@ -174,15 +176,15 @@ TU_ATTR_WEAK bool tud_vendor_control_complete_cb(uint8_t rhport, tusb_control_re
   /* CDC Header */\
   5, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_HEADER, U16_TO_U8S_LE(0x0120),\
   /* CDC Call */\
-  5, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_CALL_MANAGEMENT, 0, (_itfnum) + 1,\
+  5, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_CALL_MANAGEMENT, 0, (uint8_t)((_itfnum) + 1),\
   /* CDC ACM: support line request */\
   4, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_ABSTRACT_CONTROL_MANAGEMENT, 2,\
   /* CDC Union */\
-  5, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_UNION, _itfnum, (_itfnum) + 1,\
+  5, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_UNION, _itfnum, (uint8_t)((_itfnum) + 1),\
   /* Endpoint Notification */\
   7, TUSB_DESC_ENDPOINT, _ep_notif, TUSB_XFER_INTERRUPT, U16_TO_U8S_LE(_ep_notif_size), 16,\
   /* CDC Data Interface */\
-  9, TUSB_DESC_INTERFACE, (_itfnum)+1, 0, 2, TUSB_CLASS_CDC_DATA, 0, 0, 0,\
+  9, TUSB_DESC_INTERFACE, (uint8_t)((_itfnum)+1), 0, 2, TUSB_CLASS_CDC_DATA, 0, 0, 0,\
   /* Endpoint Out */\
   7, TUSB_DESC_ENDPOINT, _epout, TUSB_XFER_BULK, U16_TO_U8S_LE(_epsize), 0,\
   /* Endpoint In */\
@@ -240,13 +242,15 @@ TU_ATTR_WEAK bool tud_vendor_control_complete_cb(uint8_t rhport, tusb_control_re
 // MIDI simple descriptor
 // - 1 Embedded Jack In connected to 1 External Jack Out
 // - 1 Embedded Jack out connected to 1 External Jack In
+// NOTE: This returns an list of byte (uint_8) values
+// NOTE: Unwritten & unverified assumption: _itfnum is in range [0..254] (else overflows below adding 1)
 #define TUD_MIDI_DESCRIPTOR(_itfnum, _stridx, _epout, _epin, _epsize) \
   /* Audio Control (AC) Interface */\
   9, TUSB_DESC_INTERFACE, _itfnum, 0, 0, TUSB_CLASS_AUDIO, AUDIO_SUBCLASS_CONTROL, AUDIO_PROTOCOL_V1, _stridx,\
   /* AC Header */\
-  9, TUSB_DESC_CS_INTERFACE, AUDIO_CS_INTERFACE_HEADER, U16_TO_U8S_LE(0x0100), U16_TO_U8S_LE(0x0009), 1, _itfnum+1,\
+  9, TUSB_DESC_CS_INTERFACE, AUDIO_CS_INTERFACE_HEADER, U16_TO_U8S_LE(0x0100), U16_TO_U8S_LE(0x0009), 1, (uint8_t)((_itfnum)+1),\
   /* MIDI Streaming (MS) Interface */\
-  9, TUSB_DESC_INTERFACE, _itfnum+1, 0, 2, TUSB_CLASS_AUDIO, AUDIO_SUBCLASS_MIDI_STREAMING, AUDIO_PROTOCOL_V1, 0,\
+  9, TUSB_DESC_INTERFACE, (uint8_t)((_itfnum)+1), 0, 2, TUSB_CLASS_AUDIO, AUDIO_SUBCLASS_MIDI_STREAMING, AUDIO_PROTOCOL_V1, 0,\
   /* MS Header */\
   7, TUSB_DESC_CS_INTERFACE, MIDI_CS_INTERFACE_HEADER, U16_TO_U8S_LE(0x0100), U16_TO_U8S_LE(0x0025),\
   /* MS In Jack (Embedded) */\

--- a/cores/nRF5/utility/debug.cpp
+++ b/cores/nRF5/utility/debug.cpp
@@ -425,12 +425,13 @@ lookup_table_t const _strerr_table =
 
 const char* dbg_err_str(int32_t err_id)
 {
+  // TODO: verify it would be safe to change to int16_t
   const char * str = (const char *) lookup_find(&_strerr_table, err_id);
   static char unknown_str[7] = {0};
 
   if ( str == NULL )
   {
-    sprintf(unknown_str, "0x%04X", err_id);
+    sprintf(unknown_str, "0x%04lX", (uint32_t)err_id);
     str = unknown_str;
   }
 


### PR DESCRIPTION
Two types of warnings fixed.

#### First warnings:

warning: format '%X' expects argument of type 'unsigned int', but argument 3 has type 'int32_t {aka long int}' [-Wformat=]

The C++ specification requires "%X" to receive an unsigned value. Any other type (including signed values) is "undefined behavior".

#### Second set of warnings:

warning: narrowing conversion of '(((int)itfnum) + 1)' from 'int' to 'uint8_t {aka unsigned char}' inside { } [-Wnarrowing]

Affected macros were returning a list of uint8_t values, used to define statically-allocated byte arrays.  Fixed by explicitly casting to `uint8_t` when doing arithmetic on any parameter.  Notation also added to call out implied range constraint on the parameter _itfnum.