### PR TITLE
Compile without warnings

### DIFF
--- a/cores/nRF5/common_func.h
+++ b/cores/nRF5/common_func.h
@@ -171,7 +171,8 @@ const char* dbg_err_str(int32_t err_id); // TODO move to other place
 
 #define ADALOG_BUFFER(_tag, _buf, _n) \
   do {\
-    if ( _tag ) PRINTF("%-6s: len = %d\n", _tag, _n);\
+    const char * _xtag = _tag;\
+    if ( _xtag ) PRINTF("%-6s: len = %d\n", _xtag, _n);\
     dbgDumpMemory(_buf, 1, _n, true);\
   }while(0)
 

--- a/cores/nRF5/verify.h
+++ b/cores/nRF5/verify.h
@@ -62,7 +62,7 @@ extern "C"
     do { \
       const char* (*_fstr)(int32_t) = _funcstr;\
       printf("%s: %d: verify failed, error = ", __PRETTY_FUNCTION__, __LINE__);\
-      if (_fstr) printf(_fstr(_status)); else printf("%d", _status);\
+      if (_fstr) printf(_fstr(_status)); else printf("%ld", _status);\
       printf("\n");\
     }while(0)
 #else

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
@@ -179,7 +179,7 @@ const char* dbg_strerr_lfs (int32_t err)
 
     default:
       static char errcode[10];
-      sprintf(errcode, "%d", err);
+      sprintf(errcode, "%ld", err);
       return errcode;
   }
 

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
@@ -83,7 +83,7 @@ class Adafruit_LittleFS
   #define PRINT_LFS_ERR(_err)
 #else
   #define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, dbg_strerr_lfs)
-  #define PRINT_LFS_ERR(_err)   VERIFY_MESS(_err, dbg_strerr_lfs)
+  #define PRINT_LFS_ERR(_err)   VERIFY_MESS((long int)_err, dbg_strerr_lfs) // LFS_ERR are of type int, VERIFY_MESS expects long_int
 
   const char* dbg_strerr_lfs (int32_t err);
 #endif

--- a/libraries/Bluefruit52Lib/src/BLEDiscovery.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEDiscovery.cpp
@@ -84,7 +84,7 @@ bool BLEDiscovery::_discoverService(uint16_t conn_handle, BLEClientService& svc,
   // timeout or has no data (due to GATT Error)
   if ( bytecount <= 0 )
   {
-    LOG_LV1("DISC", "[SVC] timeout or error", start_handle);
+    LOG_LV1("DISC", "[SVC] timeout or error %ud", start_handle);
     return false;
   }
 

--- a/libraries/Bluefruit52Lib/src/BLEGatt.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEGatt.cpp
@@ -211,7 +211,7 @@ void BLEGatt::_eventHandler(ble_evt_t* evt)
 
       if (rd_rsp->count)
       {
-        ble_gattc_handle_value_t hdl_value = { 0, null };
+        ble_gattc_handle_value_t hdl_value = { 0, nullptr };
 
         if ( ERROR_NONE == sd_ble_gattc_evt_char_val_by_uuid_read_rsp_iter(&evt->evt.gattc_evt, &hdl_value) )
         {

--- a/libraries/Bluefruit52Lib/src/BLEGatt.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEGatt.cpp
@@ -211,7 +211,7 @@ void BLEGatt::_eventHandler(ble_evt_t* evt)
 
       if (rd_rsp->count)
       {
-        ble_gattc_handle_value_t hdl_value;
+        ble_gattc_handle_value_t hdl_value = { 0, null };
 
         if ( ERROR_NONE == sd_ble_gattc_evt_char_val_by_uuid_read_rsp_iter(&evt->evt.gattc_evt, &hdl_value) )
         {

--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -205,7 +205,7 @@ void AdafruitBluefruit::configUuid128Count(uint8_t  uuid128_max)
 
 void AdafruitBluefruit::configAttrTableSize(uint32_t attr_table_size)
 {
-  _sd_cfg.attr_table_size = align4( maxof(attr_table_size, BLE_GATTS_ATTR_TAB_SIZE_MIN) );
+  _sd_cfg.attr_table_size = align4( maxof(attr_table_size, (uint32_t)(BLE_GATTS_ATTR_TAB_SIZE_MIN)) );
 }
 
 void AdafruitBluefruit::configPrphConn(uint16_t mtu_max, uint16_t event_len, uint8_t hvn_qsize, uint8_t wrcmd_qsize)

--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -437,11 +437,11 @@ bool AdafruitBluefruit::begin(uint8_t prph_count, uint8_t central_count)
   if ( err )
   {
     LOG_LV1("CFG", "SoftDevice config require more SRAM than provided by linker.\n"
-                 "App Ram Start must be at least 0x%08X (provided 0x%08X)\n"
+                 "App Ram Start must be at least 0x%08lX (provided 0x%08lX)\n"
                  "Please update linker file or re-config SoftDevice", ram_start, (uint32_t) __data_start__);
   }
 
-  LOG_LV1("CFG", "SoftDevice's RAM requires: 0x%08X", ram_start);
+  LOG_LV1("CFG", "SoftDevice's RAM requires: 0x%08lX", ram_start);
   VERIFY_STATUS(err, false);
 
   /*------------- Configure BLE Option -------------*/

--- a/libraries/Bluefruit52Lib/src/services/BLEMidi.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEMidi.cpp
@@ -314,7 +314,7 @@ bool BLEMidi::isStatusByte( uint8_t b )
 bool BLEMidi::oneByteMessage( uint8_t status )
 {
   // system messages
-  if (status >= 0xF4 && status <= 0xFF) return true;
+  if (status >= 0xF4) return true;
 
   // system common
   if (status == 0xF1) return true;

--- a/libraries/Bluefruit52Lib/src/utility/bonding.cpp
+++ b/libraries/Bluefruit52Lib/src/utility/bonding.cpp
@@ -123,7 +123,7 @@ static void bond_save_keys_dfr (uint8_t role, uint16_t conn_hdl, bond_keys_t* bk
 
   bdata_write(&file, devname, strlen(devname)+1); // save also null char
 
-  BOND_LOG("Saved keys for \"%s\" to file %s ( %d bytes )", devname, filename, file.size());
+  BOND_LOG("Saved keys for \"%s\" to file %s ( %ld bytes )", devname, filename, file.size());
 
   file.close();
 }
@@ -178,7 +178,7 @@ static void bond_save_cccd_dfr (uint8_t role, uint16_t conn_hdl, uint16_t ediv)
 
   bdata_write(&file, sys_attr, len);
 
-  BOND_LOG("Saved CCCD setting to file %s ( offset = %d, len = %d bytes )", filename, file.size() - (len + 1), len);
+  BOND_LOG("Saved CCCD setting to file %s ( offset = %ld, len = %d bytes )", filename, file.size() - (len + 1), len);
 
   file.close();
 }
@@ -217,7 +217,7 @@ bool bond_load_cccd(uint8_t role, uint16_t conn_hdl, uint16_t ediv)
         if ( ERROR_NONE == sd_ble_gatts_sys_attr_set(conn_hdl, sys_attr, len, SVC_CONTEXT_FLAG) )
         {
           loaded = true;
-          BOND_LOG("Loaded CCCD from file %s ( offset = %d, len = %d bytes )", filename, file.size() - (len + 1), len);
+          BOND_LOG("Loaded CCCD from file %s ( offset = %ld, len = %d bytes )", filename, file.size() - (len + 1), len);
         }
       }
     }

--- a/libraries/InternalFileSytem/src/flash/flash_cache.c
+++ b/libraries/InternalFileSytem/src/flash/flash_cache.c
@@ -97,34 +97,105 @@ void flash_cache_flush (flash_cache_t* fc)
 
 void flash_cache_read (flash_cache_t* fc, void* dst, uint32_t addr, uint32_t count)
 {
+  // there is no check for overflow / wraparound for dst + count, addr + count.
+  // this might be a useful thing to add for at least debug builds.
+
   // overwrite with cache value if available
-  if ( (fc->cache_addr != FLASH_CACHE_INVALID_ADDR) &&
-       !(addr < fc->cache_addr && addr + count <= fc->cache_addr) &&
-       !(addr >= fc->cache_addr + FLASH_CACHE_SIZE) )
+  if ( (fc->cache_addr != FLASH_CACHE_INVALID_ADDR) &&               // cache is not valid
+       !(addr < fc->cache_addr && addr + count <= fc->cache_addr) && // starts before, ends before cache area
+       !(addr >= fc->cache_addr + FLASH_CACHE_SIZE) )                // starts after end of cache area
   {
-    int dst_off = fc->cache_addr - addr;
-    int src_off = 0;
-
-    if ( dst_off < 0 )
+    // This block is entered only when the read overlaps the cache area by at least one byte.
+    // If the read starts before the cache area, it's further guaranteed
+    //    that count is large enough to cause the read to enter
+    //    the cache area by at least 1 byte.
+    uint32_t dst_off = 0;
+    uint32_t src_off = 0;
+    if (addr < fc->cache_addr)
     {
-      src_off = -dst_off;
-      dst_off = 0;
+      dst_off = fc->cache_addr - addr;
+      // Read the bytes prior to the cache address
+      fc->read(dst, addr, dst_off);
     }
+    else
+    {
+      src_off = addr - fc->cache_addr;      
+    }
+    
+    // Thus, after the above code block executes:
+    // *** AT MOST ***, only one of src_off and dst_off are non-zero;
+    // (Both may be zero when the read starts at the start of the cache area.)
+    // dst_off corresponds to the number of bytes already read from PRIOR to the cache area.
+    // src_off corresponds to the byte offset to start reading at, from WITHIN the cache area.
 
-    int cache_bytes = minof(FLASH_CACHE_SIZE-src_off, count - dst_off);
+    // How many bytes to memcpy from flash area?
+    // Remember that, AT MOST, one of src_off and dst_off are non-zero.
+    // If src_off is non-zero, then dst_off is zero, representing that the
+    //   read starts inside the cache.  In this case:
+    //     PARAM1 := FLASH_CACHE_SIZE - src_off == maximum possible bytes to read from cache
+    //     PARAM2 := count
+    //   Thus, taking the minimum of the two gives the number of bytes to read from cache,
+    //     in the range [ 1 .. FLASH_CACHE_SIZE-src_off ].
+    // Else if dst_off is non-zero, then src_off is zero, representing that the
+    //   read started prior to the cache area.  In this case:
+    //     PARAM1 := FLASH_CACHE_SIZE == full size of the cache
+    //     PARAM2 := count - dst_off == total bytes requested, minus the count of those already read
+    //   Because the original request is guaranteed to overlap the cache, the range for
+    //     PARAM2 is ensured to be [ 1 .. count-1 ].
+    //   Thus, taking the minimum of the two gives the number of bytes to read from cache,
+    //     in the range [ 1 .. FLASH_CACHE_SIZE ]
+    // Else both src_off and dst_off are zero, representing that the read is starting
+    //   exactly aligned to the cache.
+    //     PARAM1 := FLASH_CACHE_SIZE
+    //     PARAM2 := count
+    //   Thus, taking the minimum of the two gives the number of bytes to read from cache,
+    //     in the range [ 1 .. FLASH_CACHE_SIZE ]
+    // 
+    // Therefore, in all cases, there is assurance that cache_bytes
+    // will be in the final range [1..FLASH_CACHE_SIZE].
+    uint32_t cache_bytes = minof(FLASH_CACHE_SIZE-src_off, count - dst_off);
 
-    // start to cached
-    if ( dst_off ) fc->read(dst, addr, dst_off);
-
-    // cached
+    // Use memcpy to read cached data into the buffer
+    // If src_off is non-zero, then dst_off is zero, representing that the
+    //   read starts inside the cache.  In this case:
+    //     PARAM1 := dst
+    //     PARAM2 := fc->cache_buf + src_off
+    //     PARAM3 := cache_bytes
+    //   Thus, all works as expected when starting in the midst of the cache.
+    // Else if dst_off is non-zero, then src_off is zero, representing that the
+    //   read started prior to the cache.  In this case:
+    //     PARAM1 := dst + dst_off == destination offset by number of bytes already read
+    //     PARAM2 := fc->cache_buf
+    //     PARAM3 := cache_bytes
+    //   Thus, all works as expected when starting prior to the cache.
+    // Else both src_off and dst_off are zero, representing that the read is starting
+    //   exactly aligned to the cache.
+    //     PARAM1 := dst
+    //     PARAM2 := fc->cache_buf
+    //     PARAM3 := cache_bytes
+    //   Thus, all works as expected when starting exactly at the cache boundary
+    // 
+    // Therefore, in all cases, there is assurance that cache_bytes
+    // will be in the final range [1..FLASH_CACHE_SIZE].
     memcpy(dst + dst_off, fc->cache_buf + src_off, cache_bytes);
 
-    // cached to end
-    int copied = dst_off + cache_bytes;
-    if ( copied < count ) fc->read(dst + copied, addr + copied, count - copied);
+    // Read any final bytes from flash
+    // As noted above, dst_off represents the count of bytes read prior to the cache
+    // while cache_bytes represents the count of bytes read from the cache;
+    // This code block is guaranteed to overlap the cache area by at least one byte.
+    // Thus, copied will correspond to the total bytes already copied,
+    // and is guaranteed to be in the range [ 1 .. count ].
+    uint32_t copied = dst_off + cache_bytes;
+    
+    // 
+    if ( copied < count )
+    {
+      fc->read(dst + copied, addr + copied, count - copied);
+    }
   }
   else
   {
+    // not using the cache, so just forward to read from flash
     fc->read(dst, addr, count);
   }
 }


### PR DESCRIPTION
This PR allows v0.14.0 to compile cleanly (no warnings), allowing end-users to focus on issues within their own code.
* Fixes #344 - Use of uninitialized variable in Bluefruit library
* Fixes #345 - InternalFileSystem compiler warnings for comparing signed vs. unsigned
* Fixes #346 - Additional Bluefruit library compiler warnings

Note: I am not sure how to fully test these.  I ran the bleuart example, and verified UART capability. 

Of particular note is the changes to the InternalFileSystem library's flash_cache.c, function flash_cache_read().  Significant comments were added to help understand the implicit guarantees provided by the various code paths.  A PowerShell function mirroring the original code flow was written to generate results from various parameters.  A second PowerShell function mirroring the new code flow was written to validate those parameters ended up with the same actions occurring  in the final code, including on all edge cases.  Manual code review validated how the old code avoided some additional edge cases, and comments now explicitly document the implicit assumptions that the old code relied heavily upon for proper operation.
