### PR TITLE
Uart: support even parity SERIAL_8E1

### DIFF
--- a/cores/nRF5/Uart.cpp
+++ b/cores/nRF5/Uart.cpp
@@ -64,7 +64,7 @@ void Uart::begin(unsigned long baudrate)
   begin(baudrate, (uint8_t)SERIAL_8N1);
 }
 
-void Uart::begin(unsigned long baudrate, uint16_t /*config*/)
+void Uart::begin(unsigned long baudrate, uint16_t config)
 {
   // skip if already begun
   if ( _begun ) return;
@@ -75,9 +75,17 @@ void Uart::begin(unsigned long baudrate, uint16_t /*config*/)
   if (uc_hwFlow == 1) {
     nrfUart->PSELCTS = uc_pinCTS;
     nrfUart->PSELRTS = uc_pinRTS;
-    nrfUart->CONFIG = (UART_CONFIG_PARITY_Excluded << UART_CONFIG_PARITY_Pos) | UART_CONFIG_HWFC_Enabled;
+    if (config==SERIAL_8E1) {
+      nrfUart->CONFIG = (UART_CONFIG_PARITY_Included << UART_CONFIG_PARITY_Pos) | UART_CONFIG_HWFC_Enabled;
+	} else {
+      nrfUart->CONFIG = (UART_CONFIG_PARITY_Excluded << UART_CONFIG_PARITY_Pos) | UART_CONFIG_HWFC_Enabled;
+	}
   } else {
-    nrfUart->CONFIG = (UART_CONFIG_PARITY_Excluded << UART_CONFIG_PARITY_Pos) | UART_CONFIG_HWFC_Disabled;
+    if (config==SERIAL_8E1) {
+      nrfUart->CONFIG = (UART_CONFIG_PARITY_Included << UART_CONFIG_PARITY_Pos) | UART_CONFIG_HWFC_Disabled;
+	} else {
+      nrfUart->CONFIG = (UART_CONFIG_PARITY_Excluded << UART_CONFIG_PARITY_Pos) | UART_CONFIG_HWFC_Disabled;
+	}
   }
 
   uint32_t nrfBaudRate;


### PR DESCRIPTION
The nRF52840 provides a second Serial interface, which now enables connecting sensors with RX/TX via Serial1 (at A0/A1). 
But the current implementation of Uart::begin(baud, config) does ignore the second configuration paramenter and sets allways SERIAL_8N1. 
This pull request does a first start and can also configure SERIAL_8E1, with EVEN parity. e.g.:  `Serial1.begin(9600, SERIAL_8E1);`