### PR TITLE
[SUPERCEDED by #397] Guard against race conditions in flash FS cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 .DS_Store
 *.swp
 /Output
+
+.vscode

--- a/cores/nRF5/rtos.cpp
+++ b/cores/nRF5/rtos.cpp
@@ -53,25 +53,18 @@ SchedulerRTOS::SchedulerRTOS(void)
   _num = 1; // loop is already created by default
 }
 
-bool SchedulerRTOS::startLoop(taskfunc_t task, uint32_t stack_size)
+bool SchedulerRTOS::startLoop(taskfunc_t task, uint32_t stack_size, uint32_t prio, const char* name)
 {
-  char name[8] = "loop0";
-  name[4] += _num;
+  char name_default[8] = "loop0";
+  name_default[4] += _num;
 
-  if ( startLoop(task, name, stack_size) )
+  if (name == NULL)
   {
-    _num++;
-    return true;
-  }else
-  {
-    return false;
+    name = name_default;
   }
-}
 
-bool SchedulerRTOS::startLoop(taskfunc_t task, const char* name, uint32_t stack_size)
-{
   TaskHandle_t  handle;
-  return pdPASS == xTaskCreate( _redirect_task, name, stack_size, (void*) task, TASK_PRIO_LOW, &handle);
+  return pdPASS == xTaskCreate( _redirect_task, name, stack_size, (void*) task, prio, &handle);
 }
 
 

--- a/cores/nRF5/rtos.cpp
+++ b/cores/nRF5/rtos.cpp
@@ -45,6 +45,7 @@ static void _redirect_task(void* arg)
   while(1)
   {
     taskfunc();
+    yield();
   }
 }
 
@@ -55,11 +56,11 @@ SchedulerRTOS::SchedulerRTOS(void)
 
 bool SchedulerRTOS::startLoop(taskfunc_t task, uint32_t stack_size, uint32_t prio, const char* name)
 {
-  char name_default[8] = "loop0";
-  name_default[4] += _num;
+  char name_default[10];
 
   if (name == NULL)
   {
+    sprintf(name_default, "loop%d", _num++);
     name = name_default;
   }
 

--- a/cores/nRF5/rtos.h
+++ b/cores/nRF5/rtos.h
@@ -92,9 +92,7 @@ public:
   typedef void (*taskfunc_t)(void);
 
   SchedulerRTOS(void);
-
-  bool startLoop(taskfunc_t task, uint32_t stack_size = SCHEDULER_STACK_SIZE_DFLT);
-  bool startLoop(taskfunc_t task, const char* name, uint32_t stack_size = SCHEDULER_STACK_SIZE_DFLT);
+  bool startLoop(taskfunc_t task, uint32_t stack_size = SCHEDULER_STACK_SIZE_DFLT, uint32_t prio = TASK_PRIO_LOW, const char* name = NULL);
 };
 
 extern SchedulerRTOS Scheduler;

--- a/cores/nRF5/utility/AdaCallback.c
+++ b/cores/nRF5/utility/AdaCallback.c
@@ -159,7 +159,7 @@ bool ada_callback_queue_resize(uint32_t new_depth)
   QueueHandle_t new_queue = xQueueCreate(new_depth, sizeof(void*));
   VERIFY(new_queue);
 
-  LOG_LV1("MEMORY", "AdaCallback increase queue depth to %d", new_depth);
+  LOG_LV1("MEMORY", "AdaCallback increase queue depth to %" PRId32, new_depth);
 
   vTaskSuspend(_cb_task);
   taskENTER_CRITICAL();

--- a/cores/nRF5/verify.h
+++ b/cores/nRF5/verify.h
@@ -58,13 +58,21 @@ extern "C"
 #if CFG_DEBUG >= 1
 #include <stdio.h>
 
-  #define VERIFY_MESS(_status, _funcstr) \
-    do { \
-      const char* (*_fstr)(int32_t) = _funcstr;\
-      printf("%s: %d: verify failed, error = ", __PRETTY_FUNCTION__, __LINE__);\
-      if (_fstr) printf(_fstr(_status)); else printf("%ld", _status);\
-      printf("\n");\
-    }while(0)
+  #define VERIFY_MESS(_status, _functstr) VERIFY_MESS_impl(_status, _functstr, __PRETTY_FUNCTION__, __LINE__)
+
+  static inline void VERIFY_MESS_impl(int32_t _status, const char* (*_fstr)(int32_t), const char* func_name, int line_number)
+  {
+      printf("%s: %d: verify failed, error = ", func_name, line_number);
+      if (_fstr)
+      {
+        printf(_fstr(_status));
+      }
+      else
+      {
+        printf("%ld", _status);
+      }
+      printf("\n");
+  }
 #else
   #define VERIFY_MESS(_status, _funcstr)
 #endif

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -105,13 +105,15 @@ void list_files(void)
           file.read(buffer, sizeof(buffer)-1);
 
           Serial.print(buffer);
-          delay(100);
+          delay(10);
         }
         file.close();
 
         Serial.println("---------------\n");
       }
     }
+
+    subdir.close();
   }
 }
 
@@ -129,7 +131,7 @@ void loop()
       list_files();
     }
 
-    delay(100);
+    delay(1000);
     vTaskSuspend(NULL); // suspend task
     return;
   }
@@ -142,5 +144,5 @@ void loop()
   write_files(name);
 
   // lower delay increase chance for high prio task preempt others.
-  delay(500);
+  delay(100);
 }

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -25,7 +25,7 @@ using namespace Adafruit_LittleFS_Namespace;
  */
 
 // timeout in seconds
-#define TIME_OUT      600
+#define TIME_OUT      20
 
 uint32_t writeCount = 0;
 
@@ -51,11 +51,11 @@ void setup()
   // and running with different priorities
 
   // Note: default loop() is running at LOW
-  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "normal");
-  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "normal");
-  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "normal");
-  Scheduler.startLoop(loop, 1024, TASK_PRIO_HIGH, "high");
   //Scheduler.startLoop(loop, 1024, TASK_PRIO_HIGHEST, "highest");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_HIGH, "high");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "n1");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "n2");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "n3");
 }
 
 void write_files(const char * name)
@@ -67,7 +67,7 @@ void write_files(const char * name)
 
   if ( file.open(fname, FILE_O_WRITE) )
   {
-    file.printf("%s %d\n", name, writeCount++);
+    file.printf("%d\n", writeCount++);
     file.close();
   }else
   {
@@ -114,6 +114,7 @@ void loop()
       list_files();
     }
 
+    delay(100);
     vTaskSuspend(NULL); // suspend task
     return;
   }

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -28,7 +28,7 @@ using namespace Adafruit_LittleFS_Namespace;
  */
 
 // timeout in seconds
-#define TIME_OUT      30
+#define TIME_OUT      60
 
 // Limit number of writes since our internal flash is limited (28 KB in total)
 #define WRITE_COUNT   2000

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -28,7 +28,7 @@ using namespace Adafruit_LittleFS_Namespace;
  */
 
 // timeout in seconds
-#define TIME_OUT      60
+#define TIME_OUT      30
 
 // Limit number of writes since our internal flash is limited (28 KB in total)
 #define WRITE_COUNT   2000

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -155,7 +155,7 @@ void loop()
       list_files();
     }
 
-    delay(1000);uint32_t duration_ms = 0;
+    delay(1000);
     vTaskSuspend(NULL); // suspend task
     return;
   }
@@ -165,7 +165,6 @@ void loop()
   Serial.flush();
 
   // Write files
-  uint32_t duration_ms = 0;
   write_files(name);
 
   // lower delay increase chance for high prio task preempt others.

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -25,9 +25,9 @@ using namespace Adafruit_LittleFS_Namespace;
  */
 
 // timeout in seconds
-#define TIME_OUT      5
+#define TIME_OUT      600
 
-bool summarized = false;
+uint32_t writeCount = 0;
 
 // the setup function runs once when you press reset or power the board
 void setup() 
@@ -65,7 +65,7 @@ void write_files(const char * name)
 
   if ( file.open(fname, FILE_O_WRITE) )
   {
-    file.println(name);
+    file.printf("%d\n", writeCount++);
     file.close();
   }else
   {
@@ -91,11 +91,11 @@ void list_files(void)
       readlen = file.read(buffer, sizeof(buffer));
 
       Serial.print(buffer);
+      delay(100);
     }
     file.close();
 
     Serial.println("---------------\n");
-    Serial.flush();
   }
 }
 
@@ -107,9 +107,9 @@ void loop()
   if ( millis() > TIME_OUT*1000 )
   {
     // low priority task print summary
-    if ( !summarized && (TASK_PRIO_LOW == uxTaskPriorityGet(th)))
+    if (TASK_PRIO_LOW == uxTaskPriorityGet(th))
     {
-      summarized = true;
+      Serial.printf("Total write count = %d\n", writeCount);
       list_files();
     }
 
@@ -125,5 +125,5 @@ void loop()
   write_files(name);
 
   // lower delay increase chance for high prio task preempt others.
-  delay(100);
+  delay(500);
 }

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -28,7 +28,7 @@ using namespace Adafruit_LittleFS_Namespace;
  */
 
 // timeout in seconds
-#define TIME_OUT      600
+#define TIME_OUT      60
 
 // Limit number of writes since our internal flash is limited (28 KB in total)
 #define WRITE_COUNT   2000
@@ -151,7 +151,7 @@ void loop()
     // low priority task print summary
     if (TASK_PRIO_LOW == uxTaskPriorityGet(th))
     {
-      Serial.printf("Total write count = %d in %f seconds\n", writeCount, millis()/1000);
+      Serial.printf("Total write count = %d in %.2f seconds\n", writeCount, millis()/1000.0);
       list_files();
     }
 

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -1,0 +1,129 @@
+/*********************************************************************
+ This is an example for our nRF52 based Bluefruit LE modules
+
+ Pick one up today in the adafruit shop!
+
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
+
+#include <Adafruit_LittleFS.h>
+#include <InternalFileSystem.h>
+
+using namespace Adafruit_LittleFS_Namespace;
+
+/* This example perform a stress test on Little FileSystem on internal flash.
+ * There are 4 different thread sharing same loop() code with different priority
+ *    loop (low), normal, high, highest
+ * Each will open and write a file of its name (+ .txt). Task takes turn writing until timeout
+ * to print out the summary
+ */
+
+// timeout in seconds
+#define TIME_OUT      5
+
+bool summarized = false;
+
+// the setup function runs once when you press reset or power the board
+void setup() 
+{
+  Serial.begin(115200);
+  while ( !Serial ) yield();   // for nrf52840 with native usb
+
+  Serial.println("Internal Stress Test Example");
+  yield();
+
+  // Initialize Internal File System
+  InternalFS.begin();
+
+  // Format
+  Serial.print("Formatting ... "); Serial.flush();
+  InternalFS.format();
+  Serial.println("Done"); Serial.flush();
+
+  // Create thread with different priority
+  // Although all the thread share loop() code, they are separated threads
+  // and running with different priorities
+
+  // Note: default loop() is running at LOW
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "normal");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_HIGH, "high");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_HIGHEST, "highest");
+}
+
+void write_files(const char * name)
+{
+  char fname[20] = { 0 };
+  sprintf(fname, "%s.txt", name);
+
+  File file(InternalFS);
+
+  if ( file.open(fname, FILE_O_WRITE) )
+  {
+    file.println(name);
+    file.close();
+  }else
+  {
+    Serial.printf("Failed to open %s\n", fname);
+  }
+}
+
+void list_files(void)
+{
+  File dir("/", FILE_O_READ, InternalFS);
+  File file(InternalFS);
+
+  while( (file = dir.openNextFile(FILE_O_READ)) )
+  {
+    if ( file.isDirectory() ) continue;
+
+    Serial.printf("--- %s ---\n", file.name());
+
+    while ( file.available() )
+    {
+      uint32_t readlen;
+      char buffer[64] = { 0 };
+      readlen = file.read(buffer, sizeof(buffer));
+
+      Serial.print(buffer);
+    }
+    file.close();
+
+    Serial.println("---------------\n");
+    Serial.flush();
+  }
+}
+
+// the loop function runs over and over again forever
+void loop() 
+{
+  TaskHandle_t th = xTaskGetCurrentTaskHandle();
+
+  if ( millis() > TIME_OUT*1000 )
+  {
+    // low priority task print summary
+    if ( !summarized && (TASK_PRIO_LOW == uxTaskPriorityGet(th)))
+    {
+      summarized = true;
+      list_files();
+    }
+
+    vTaskSuspend(NULL); // suspend task
+    return;
+  }
+
+  const char* name = pcTaskGetName(th);
+  Serial.printf( "Task %s writing ...\n", name );
+  Serial.flush();
+
+  // Write files
+  write_files(name);
+
+  // lower delay increase chance for high prio task preempt others.
+  delay(100);
+}

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -52,8 +52,10 @@ void setup()
 
   // Note: default loop() is running at LOW
   Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "normal");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "normal");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "normal");
   Scheduler.startLoop(loop, 1024, TASK_PRIO_HIGH, "high");
-  Scheduler.startLoop(loop, 1024, TASK_PRIO_HIGHEST, "highest");
+  //Scheduler.startLoop(loop, 1024, TASK_PRIO_HIGHEST, "highest");
 }
 
 void write_files(const char * name)
@@ -65,7 +67,7 @@ void write_files(const char * name)
 
   if ( file.open(fname, FILE_O_WRITE) )
   {
-    file.printf("%d\n", writeCount++);
+    file.printf("%s %d\n", name, writeCount++);
     file.close();
   }else
   {
@@ -86,9 +88,8 @@ void list_files(void)
 
     while ( file.available() )
     {
-      uint32_t readlen;
       char buffer[64] = { 0 };
-      readlen = file.read(buffer, sizeof(buffer));
+      file.read(buffer, sizeof(buffer)-1);
 
       Serial.print(buffer);
       delay(100);

--- a/libraries/InternalFileSytem/src/InternalFileSystem.cpp
+++ b/libraries/InternalFileSytem/src/InternalFileSystem.cpp
@@ -132,6 +132,8 @@ InternalFileSystem::InternalFileSystem(void)
 
 bool InternalFileSystem::begin(void)
 {
+  flash_nrf5x_init();
+
   // failed to mount, erase all sector then format and mount again
   if ( !Adafruit_LittleFS::begin() )
   {

--- a/libraries/InternalFileSytem/src/flash/flash_cache.c
+++ b/libraries/InternalFileSytem/src/flash/flash_cache.c
@@ -43,12 +43,6 @@ static void _internal_flash_cache_flush (flash_cache_t* fc);
 //--------------------------------------------------------------------+
 static inline void _internal_TakeFlashCacheSerialization(flash_cache_t* fc)
 {
-  // This only executes one
-  if ( fc->mutex == NULL )
-  {
-    fc->mutex = xSemaphoreCreateMutexStatic(&fc->mutex_storage);
-  }
-
 #if CFG_DEBUG >= 2
   if ( 0 == uxSemaphoreGetCount(fc->mutex) )
   {
@@ -61,10 +55,7 @@ static inline void _internal_TakeFlashCacheSerialization(flash_cache_t* fc)
 
 static inline void _internal_ReleaseFlashCacheSerialization(flash_cache_t* fc)
 {
-  if ( fc->mutex )
-  {
-    xSemaphoreGive(fc->mutex);
-  }
+  xSemaphoreGive(fc->mutex);
 }
 
 static inline uint32_t page_addr_of (uint32_t addr)
@@ -75,6 +66,16 @@ static inline uint32_t page_addr_of (uint32_t addr)
 static inline uint32_t page_offset_of (uint32_t addr)
 {
   return addr & (FLASH_CACHE_SIZE - 1);
+}
+
+
+// Should be safe to call multiple times
+void flash_cache_init (flash_cache_t* fc)
+{
+  if ( fc->mutex == NULL )
+  {
+    fc->mutex = xSemaphoreCreateMutexStatic(&fc->mutex_storage);
+  }
 }
 
 //--------------------------------------------------------------------+

--- a/libraries/InternalFileSytem/src/flash/flash_cache.c
+++ b/libraries/InternalFileSytem/src/flash/flash_cache.c
@@ -22,11 +22,61 @@
  * THE SOFTWARE.
  */
 
+#include <FreeRTOS.h>
+#include <semphr.h> // This ties to FreeRTOS ... used to serialize flash access
+
+#include "flash_nrf5x.h"
+#include "flash_cache.h"
+#include "nrf_sdm.h"
+#include "nrf_soc.h"
+#include "delay.h"
+#include "rtos.h"
+
+
 #include <string.h>
 #include "flash_cache.h"
 #include "common_func.h"
 #include "variant.h"
 #include "wiring_digital.h"
+
+
+
+static volatile SemaphoreHandle_t _serializeFlashAccess = NULL;
+
+static inline void EnsureSemaphoreInitialized()
+{
+  // once the value is non-null, no synchronization required
+  while (NULL == _serializeFlashAccess)
+  {
+    SemaphoreHandle_t newSemaphore = xSemaphoreCreateRecursiveMutex();
+    if (NULL == newSemaphore)
+    {
+      LOG_LV2("IFLASH", "Unable to allocate semaphore for InternalFS ... will retry");
+      delay(1);
+    }
+    // want one, and exactly one, semaphore to be stored in the global
+    // if multiple initializations, only one will replace a NULL value
+    // note that this atomic intrinsic has built-in memory barrier semantics
+    (void)__sync_bool_compare_and_swap(&_serializeFlashAccess, NULL, newSemaphore);
+  }
+}
+static inline void TakeMutex()
+{
+  EnsureSemaphoreInitialized();
+  if (pdTRUE == xSemaphoreTakeRecursive(_serializeFlashAccess, 0)) {
+    return;
+  }
+  LOG_LV2("IFLASH", "Blocked parallel write attempt ... waiting for mutex");
+  while (pdTRUE != xSemaphoreTakeRecursive(_serializeFlashAccess,  portMAX_DELAY))
+  {
+    // nothing
+  }
+}
+static inline void ReleaseMutex()
+{
+  xSemaphoreGiveRecursive(_serializeFlashAccess);
+}
+
 
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION
@@ -43,6 +93,8 @@ static inline uint32_t page_offset_of (uint32_t addr)
 
 int flash_cache_write (flash_cache_t* fc, uint32_t dst, void const * src, uint32_t len)
 {
+  TakeMutex();
+
   uint8_t const * src8 = (uint8_t const *) src;
   uint32_t remain = len;
 
@@ -73,12 +125,19 @@ int flash_cache_write (flash_cache_t* fc, uint32_t dst, void const * src, uint32
     dst += wr_bytes;
   }
 
+  ReleaseMutex();
   return len - remain;
 }
 
 void flash_cache_flush (flash_cache_t* fc)
 {
-  if ( fc->cache_addr == FLASH_CACHE_INVALID_ADDR ) return;
+  TakeMutex();
+
+  if ( fc->cache_addr == FLASH_CACHE_INVALID_ADDR )
+  {
+    ReleaseMutex();
+    return;
+  }
 
   // skip erase & program if verify() exists, and memory matches
   if ( !(fc->verify && fc->verify(fc->cache_addr, fc->cache_buf, FLASH_CACHE_SIZE)) )
@@ -97,6 +156,7 @@ void flash_cache_flush (flash_cache_t* fc)
 
 int flash_cache_read (flash_cache_t* fc, void* dst, uint32_t addr, uint32_t count)
 {
+  TakeMutex();
   // there is no check for overflow / wraparound for dst + count, addr + count.
   // this might be a useful thing to add for at least debug builds.
 
@@ -198,6 +258,7 @@ int flash_cache_read (flash_cache_t* fc, void* dst, uint32_t addr, uint32_t coun
     // not using the cache, so just forward to read from flash
     fc->read(dst, addr, count);
   }
+  ReleaseMutex();
 
   return (int) count;
 }

--- a/libraries/InternalFileSytem/src/flash/flash_cache.c
+++ b/libraries/InternalFileSytem/src/flash/flash_cache.c
@@ -43,6 +43,10 @@
 
 static volatile SemaphoreHandle_t _serializeFlashAccess = NULL;
 
+int  _internal_flash_cache_write (flash_cache_t* fc, uint32_t dst, void const * src, uint32_t len);
+int  _internal_flash_cache_read  (flash_cache_t* fc, void* dst, uint32_t addr, uint32_t count);
+void _internal_flash_cache_flush (flash_cache_t* fc);
+
 static inline void _internal_EnsureFlashCacheSemaphoreInitialized()
 {
   // once the value is non-null, no synchronization required

--- a/libraries/InternalFileSytem/src/flash/flash_cache.h
+++ b/libraries/InternalFileSytem/src/flash/flash_cache.h
@@ -27,6 +27,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include "FreeRTOS.h"
+#include "semphr.h"
 
 #define FLASH_CACHE_SIZE          4096        // must be a erasable page size
 #define FLASH_CACHE_INVALID_ADDR  0xffffffff
@@ -40,6 +42,9 @@ typedef struct
 
     uint32_t cache_addr;
     uint8_t* cache_buf;
+
+    SemaphoreHandle_t mutex;
+    StaticSemaphore_t mutex_storage;
 } flash_cache_t;
 
 #ifdef __cplusplus

--- a/libraries/InternalFileSytem/src/flash/flash_cache.h
+++ b/libraries/InternalFileSytem/src/flash/flash_cache.h
@@ -51,9 +51,10 @@ typedef struct
 extern "C" {
 #endif
 
-int flash_cache_write (flash_cache_t* fc, uint32_t dst, void const *src, uint32_t count);
-void flash_cache_flush (flash_cache_t* fc);
-int flash_cache_read (flash_cache_t* fc, void* dst, uint32_t addr, uint32_t count);
+void flash_cache_init (flash_cache_t* fc);
+int  flash_cache_write(flash_cache_t* fc, uint32_t dst, void const *src, uint32_t count);
+void flash_cache_flush(flash_cache_t* fc);
+int  flash_cache_read (flash_cache_t* fc, void* dst, uint32_t addr, uint32_t count);
 
 #ifdef __cplusplus
  }

--- a/libraries/InternalFileSytem/src/flash/flash_nrf5x.c
+++ b/libraries/InternalFileSytem/src/flash/flash_nrf5x.c
@@ -67,7 +67,10 @@ static flash_cache_t _cache =
   .verify     = fal_verify,
 
   .cache_addr = FLASH_CACHE_INVALID_ADDR,
-  .cache_buf  = _cache_buffer
+  .cache_buf  = _cache_buffer,
+
+  .mutex      = NULL,
+  //.mutex_storage = { 0 }  // no need to initialize mutex storage
 };
 
 //--------------------------------------------------------------------+

--- a/libraries/InternalFileSytem/src/flash/flash_nrf5x.h
+++ b/libraries/InternalFileSytem/src/flash/flash_nrf5x.h
@@ -33,6 +33,7 @@
  extern "C" {
 #endif
 
+void flash_nrf5x_init(void);
 void flash_nrf5x_flush (void);
 bool flash_nrf5x_erase(uint32_t addr);
 


### PR DESCRIPTION
Serialize all the flash_cache read/write/flush functions.

This is necessary because these functions may be called by multiple tasks simultaneously, and because these functions use and modify shared state.

@hathach, @ladyada -- This change compiles, but I **_recommend your validation_**, as I have been unable to do so myself.  That said, this has a very strong likelihood of resolving the file system corruption issues.  Testing should include repeated BLE pairing and main sketch file system use.

After additional testing, this PR should fix the following issues:
Fix #350
Fix #325
Fix #227
Fix #222

