### PR TITLE
Split TravisCI build into one job per variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,14 @@ git:
   quiet: true
 
 env:
-  - BSP_PATH="$HOME/.arduino15/packages/adafruit/hardware/nrf52"
-  
+  global:
+    - BSP_PATH="$HOME/.arduino15/packages/adafruit/hardware/nrf52"
+  jobs:
+    # Split into one job per board (aka variant)
+    - VARIANT="feather52840"
+    - VARIANT="cplaynrf52840"
+    - VARIANT="feather52832"
+    
 addons:
   apt:
     packages:

--- a/tools/build_all.py
+++ b/tools/build_all.py
@@ -65,8 +65,23 @@ def build_examples(variant):
 
 build_time = time.monotonic()
 
-for var in variants_dict:
-    build_examples(var)
+ENV_VARIABLE_NAME = 'VARIANT'
+
+# build only one variant if the environment variable is specified
+if (ENV_VARIABLE_NAME in os.environ):
+    variant = os.environ.get(ENV_VARIABLE_NAME)
+    # only use the environment variable if the variant exists in the dictionary
+    if (variant in variants_dict):
+        build_examples(variant)
+    else:
+        print('\033[31failed\033[0m - invalid variant name "{}"'.format(variant))
+        fail_count += 1
+        exit_status = -1
+
+else: # no environment variable specified, so build all variants
+    for var in variants_dict:
+        build_examples(var)
+
 
 print(build_separator)
 build_time = time.monotonic() - build_time


### PR DESCRIPTION
Fixes #371

TravisCI imposes a per-job time limit.  This limit is fixed and non-configurable for free accounts as **`50`** minutes.  This limit is configurable but cannot exceed **`120`** minutes for enterprise / paid accounts.

The builds are currently taking approximately 75 minutes, building all samples for three distinct boards (variants) in a single job.  Because 75 minutes is greater than 50 minutes, this prevents users with only a free account from validating their changes using TravisCI prior to submitting their pull requests.

This change also dramatically reduces the (wall-clock) time for validation of a successful build (from ~75 minutes down to ~30 minutes).
