### PR TITLE
Serialize lfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.o
 *.obj
 
+# Visual Studio Code
+.vscode/
+
 # Executables
 *.out
 *.app

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 *.obj
 
 # Visual Studio Code
-.vscode/
+**/.vscode/
 
 # Executables
 *.out

--- a/cores/nRF5/rtos.cpp
+++ b/cores/nRF5/rtos.cpp
@@ -45,13 +45,12 @@ static void _redirect_task(void* arg)
   while(1)
   {
     taskfunc();
-    delay(0);
+    yield();
   }
 }
 
 SchedulerRTOS::SchedulerRTOS(void)
 {
-  _num = 1; // loop is already created by default
 }
 
 bool SchedulerRTOS::startLoop(taskfunc_t task, uint32_t stack_size, uint32_t prio, const char* name)

--- a/cores/nRF5/rtos.cpp
+++ b/cores/nRF5/rtos.cpp
@@ -45,6 +45,7 @@ static void _redirect_task(void* arg)
   while(1)
   {
     taskfunc();
+    delay(0);
   }
 }
 
@@ -53,25 +54,15 @@ SchedulerRTOS::SchedulerRTOS(void)
   _num = 1; // loop is already created by default
 }
 
-bool SchedulerRTOS::startLoop(taskfunc_t task, uint32_t stack_size)
+bool SchedulerRTOS::startLoop(taskfunc_t task, uint32_t stack_size, uint32_t prio, const char* name)
 {
-  char name[8] = "loop0";
-  name[4] += _num;
-
-  if ( startLoop(task, name, stack_size) )
+  static char const * const name_default = "unnamed_task";
+  if (name == NULL)
   {
-    _num++;
-    return true;
-  }else
-  {
-    return false;
+    name = name_default;
   }
-}
-
-bool SchedulerRTOS::startLoop(taskfunc_t task, const char* name, uint32_t stack_size)
-{
   TaskHandle_t  handle;
-  return pdPASS == xTaskCreate( _redirect_task, name, stack_size, (void*) task, TASK_PRIO_LOW, &handle);
+  return pdPASS == xTaskCreate( _redirect_task, name, stack_size, (void*) task, prio, &handle);
 }
 
 

--- a/cores/nRF5/rtos.h
+++ b/cores/nRF5/rtos.h
@@ -85,9 +85,6 @@ static inline void rtos_free( void *pv )
 
 class SchedulerRTOS
 {
-private:
-  uint8_t _num;
-
 public:
   typedef void (*taskfunc_t)(void);
 

--- a/cores/nRF5/rtos.h
+++ b/cores/nRF5/rtos.h
@@ -93,8 +93,7 @@ public:
 
   SchedulerRTOS(void);
 
-  bool startLoop(taskfunc_t task, uint32_t stack_size = SCHEDULER_STACK_SIZE_DFLT);
-  bool startLoop(taskfunc_t task, const char* name, uint32_t stack_size = SCHEDULER_STACK_SIZE_DFLT);
+  bool startLoop(taskfunc_t task, uint32_t stack_size = SCHEDULER_STACK_SIZE_DFLT, uint32_t prio = TASK_PRIO_LOW, const char* name = NULL);
 };
 
 extern SchedulerRTOS Scheduler;

--- a/cores/nRF5/utility/AdaCallback.c
+++ b/cores/nRF5/utility/AdaCallback.c
@@ -153,7 +153,7 @@ bool ada_callback_queue_resize(uint32_t new_depth)
   QueueHandle_t new_queue = xQueueCreate(new_depth, sizeof(void*));
   VERIFY(new_queue);
 
-  LOG_LV1("MEMORY", "AdaCallback increase queue depth to %d", new_depth);
+  LOG_LV1("MEMORY", "AdaCallback increase queue depth to %" PRId32, new_depth);
 
   vTaskSuspend(_cb_task);
   taskENTER_CRITICAL();

--- a/cores/nRF5/verify.h
+++ b/cores/nRF5/verify.h
@@ -57,14 +57,20 @@ extern "C"
 //--------------------------------------------------------------------+
 #if CFG_DEBUG >= 1
 #include <stdio.h>
-
-  #define VERIFY_MESS(_status, _funcstr) \
-    do { \
-      const char* (*_fstr)(int32_t) = _funcstr;\
-      printf("%s: %d: verify failed, error = ", __PRETTY_FUNCTION__, __LINE__);\
-      if (_fstr) printf(_fstr(_status)); else printf("%ld", _status);\
-      printf("\n");\
-    }while(0)
+  #define VERIFY_MESS(_status, _functstr) VERIFY_MESS_impl(_status, _functstr, __PRETTY_FUNCTION__, __LINE__)
+  static inline void VERIFY_MESS_impl(int32_t _status, const char* (*_fstr)(int32_t), const char* func_name, int line_number)
+  {
+      printf("%s: %d: verify failed, error = ", func_name, line_number);
+      if (_fstr)
+      {
+        printf(_fstr(_status));
+      }
+      else
+      {
+        printf("%ld", _status);
+      }
+      printf("\n");
+  }
 #else
   #define VERIFY_MESS(_status, _funcstr)
 #endif

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
@@ -121,10 +121,8 @@ bool Adafruit_LittleFS::format (void)
 // Open a file or folder
 Adafruit_LittleFS_Namespace::File Adafruit_LittleFS::open (char const *filepath, uint8_t mode)
 {
-  xSemaphoreTake(_mutex,  portMAX_DELAY);
-  Adafruit_LittleFS_Namespace::File ret = Adafruit_LittleFS_Namespace::File(filepath, mode, *this);
-  xSemaphoreGive(_mutex);
-  return ret;
+  // No lock is required here ... the File() object will synchronize with the mutex provided
+  return Adafruit_LittleFS_Namespace::File(filepath, mode, *this);
 }
 
 // Check if file or folder exists

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
@@ -44,7 +44,7 @@ Adafruit_LittleFS::Adafruit_LittleFS (struct lfs_config* cfg)
   varclr(&_lfs);
   _lfs_cfg = cfg;
   _mounted = false;
-  _mutex = xSemaphoreCreateMutexStatic(&this->xMutexStorageSpace);
+  _mutex = xSemaphoreCreateMutexStatic(&this->_MutexStorageSpace);
 }
 
 Adafruit_LittleFS::~Adafruit_LittleFS ()
@@ -57,176 +57,159 @@ Adafruit_LittleFS::~Adafruit_LittleFS ()
 // User should format the disk and try again
 bool Adafruit_LittleFS::begin (struct lfs_config * cfg)
 {
-  while (pdTRUE != xSemaphoreTake(_mutex,  portMAX_DELAY)) {}
-  bool retval = this->xWrap_begin(cfg);
+  xSemaphoreTake(_mutex,  portMAX_DELAY);
+  bool ret;
+  // not a loop, just an quick way to short-circuit on error
+  do {
+    if (_mounted) { ret = true; break; }
+    if (cfg) { _lfs_cfg = cfg; }
+    if (nullptr == _lfs_cfg) { ret = false; break; }
+    // actually attempt to mount, and log error if one occurs
+    int err = lfs_mount(&_lfs, _lfs_cfg);
+    PRINT_LFS_ERR(err);
+    _mounted = (err == LFS_ERR_OK);
+    ret = _mounted;
+  } while(0);
   xSemaphoreGive(_mutex);
-  return retval;
-}
-
-bool Adafruit_LittleFS::xWrap_begin (struct lfs_config * cfg)
-{
-  if ( _mounted ) return true;
-
-  if (cfg) _lfs_cfg = cfg;
-  if (!_lfs_cfg) return false;
-
-  VERIFY_LFS(lfs_mount(&_lfs, _lfs_cfg), false);
-  _mounted = true;
-
-  return true;
+  return ret;
 }
 
 // Tear down and unmount file system
 void Adafruit_LittleFS::end(void)
 {
-  while (pdTRUE != xSemaphoreTake(_mutex,  portMAX_DELAY)) {}
-  this->xWrap_end();
+  xSemaphoreTake(_mutex,  portMAX_DELAY);
+  if (_mounted)
+  {
+    _mounted = false;
+    int err = lfs_unmount(&_lfs);
+    PRINT_LFS_ERR(err);
+    (void)err;
+  }
   xSemaphoreGive(_mutex);
-}
-
-void Adafruit_LittleFS::xWrap_end(void)
-{
-  if (!_mounted) return;
-
-  _mounted = false;
-  VERIFY_LFS(lfs_unmount(&_lfs), );
 }
 
 bool Adafruit_LittleFS::format (void)
 {
-  while (pdTRUE != xSemaphoreTake(_mutex,  portMAX_DELAY)) {}
-  bool retval = this->xWrap_format();
+  xSemaphoreTake(_mutex,  portMAX_DELAY);
+  int err = LFS_ERR_OK;
+  bool attemptMount = _mounted;
+  // not a loop, just an quick way to short-circuit on error
+  do
+  {
+    // if already mounted: umount first -> format -> remount
+    if (_mounted)
+    {
+      _mounted = false;
+      err = lfs_unmount(&_lfs);
+      if ( LFS_ERR_OK != err) { PRINT_LFS_ERR(err); break; }
+    }
+    err = lfs_format(&_lfs, _lfs_cfg);
+    if ( LFS_ERR_OK != err ) { PRINT_LFS_ERR(err); break; }
+
+    if (attemptMount)
+    {
+      err = lfs_mount(&_lfs, _lfs_cfg);
+      if ( LFS_ERR_OK != err ) { PRINT_LFS_ERR(err); break; }
+      _mounted = true;
+    }
+    // success!
+  } while(0);
   xSemaphoreGive(_mutex);
-  return retval;
-}
-
-bool Adafruit_LittleFS::xWrap_format (void)
-{
-  // if already mounted: umount -> format -> remount
-  if(_mounted) VERIFY_LFS(lfs_unmount(&_lfs), false);
-
-  VERIFY_LFS(lfs_format(&_lfs, _lfs_cfg), false);
-
-  if (_mounted) VERIFY_LFS(lfs_mount(&_lfs, _lfs_cfg), false);
-
-  return true;
+  return LFS_ERR_OK == err;
 }
 
 // Open a file or folder
 Adafruit_LittleFS_Namespace::File Adafruit_LittleFS::open (char const *filepath, uint8_t mode)
 {
-  while (pdTRUE != xSemaphoreTake(_mutex,  portMAX_DELAY)) {}
-  Adafruit_LittleFS_Namespace::File retval = this->xWrap_open(filepath, mode);
+  xSemaphoreTake(_mutex,  portMAX_DELAY);
+  Adafruit_LittleFS_Namespace::File ret = Adafruit_LittleFS_Namespace::File(filepath, mode, *this);
   xSemaphoreGive(_mutex);
-  return retval;
-}
-
-Adafruit_LittleFS_Namespace::File Adafruit_LittleFS::xWrap_open (char const *filepath, uint8_t mode)
-{
-  return Adafruit_LittleFS_Namespace::File(filepath, mode, *this);
+  return ret;
 }
 
 // Check if file or folder exists
 bool Adafruit_LittleFS::exists (char const *filepath)
 {
-  while (pdTRUE != xSemaphoreTake(_mutex,  portMAX_DELAY)) {}
-  bool retval = this->xWrap_exists(filepath);
+  struct lfs_info info;
+  xSemaphoreTake(_mutex,  portMAX_DELAY);
+  bool ret = (0 == lfs_stat(&_lfs, filepath, &info));
   xSemaphoreGive(_mutex);
-  return retval;
+  return ret;
 }
 
-bool Adafruit_LittleFS::xWrap_exists (char const *filepath)
-{
-  struct lfs_info info;
-  return 0 == lfs_stat(&_lfs, filepath, &info);
-}
 
 // Create a directory, create intermediate parent if needed
 bool Adafruit_LittleFS::mkdir (char const *filepath)
 {
-  while (pdTRUE != xSemaphoreTake(_mutex,  portMAX_DELAY)) {}
-  bool retval = this->xWrap_mkdir(filepath);
-  xSemaphoreGive(_mutex);
-  return retval;
-}
-
-bool Adafruit_LittleFS::xWrap_mkdir (char const *filepath)
-{
+  bool ret = true;
   const char* slash = filepath;
   if ( slash[0] == '/' ) slash++;    // skip root '/'
 
+  xSemaphoreTake(_mutex,  portMAX_DELAY);
+
+  // make intermediate parent directory(ies)
   while ( NULL != (slash = strchr(slash, '/')) )
   {
     char parent[slash - filepath + 1] = { 0 };
     memcpy(parent, filepath, slash - filepath);
 
-    // make intermediate parent
     int rc = lfs_mkdir(&_lfs, parent);
     if ( rc != LFS_ERR_OK && rc != LFS_ERR_EXIST )
     {
       PRINT_LFS_ERR(rc);
-      return false;
+      ret = false;
+      break;
     }
-
     slash++;
   }
-  
-  int rc = lfs_mkdir(&_lfs, filepath);
-  if ( rc != LFS_ERR_OK && rc != LFS_ERR_EXIST )
+  // make the final requested directory
+  if (ret)
   {
-    PRINT_LFS_ERR(rc);
-    return false;
+    int rc = lfs_mkdir(&_lfs, filepath);
+    if ( rc != LFS_ERR_OK && rc != LFS_ERR_EXIST )
+    {
+      PRINT_LFS_ERR(rc);
+      ret = false;
+    }
   }
-
-  return true;
+  xSemaphoreGive(_mutex);
+  return ret;
 }
 
 // Remove a file
 bool Adafruit_LittleFS::remove (char const *filepath)
 {
-  while (pdTRUE != xSemaphoreTake(_mutex,  portMAX_DELAY)) {}
-  bool retval = this->xWrap_remove(filepath);
+  xSemaphoreTake(_mutex,  portMAX_DELAY);
+  int err = lfs_remove(&_lfs, filepath);
+  PRINT_LFS_ERR(err);
   xSemaphoreGive(_mutex);
-  return retval;
-}
-
-bool Adafruit_LittleFS::xWrap_remove (char const *filepath)
-{
-  VERIFY_LFS(lfs_remove(&_lfs, filepath), false);
-  return true;
+  return LFS_ERR_OK == err;
 }
 
 // Remove a folder
 bool Adafruit_LittleFS::rmdir (char const *filepath)
 {
-  while (pdTRUE != xSemaphoreTake(_mutex,  portMAX_DELAY)) {}
-  bool retval = this->xWrap_rmdir(filepath);
+  xSemaphoreTake(_mutex,  portMAX_DELAY);
+  int err = lfs_remove(&_lfs, filepath);
+  PRINT_LFS_ERR(err);
   xSemaphoreGive(_mutex);
-  return retval;
-}
-
-bool Adafruit_LittleFS::xWrap_rmdir (char const *filepath)
-{
-  VERIFY_LFS(lfs_remove(&_lfs, filepath));
-  return true;
+  return LFS_ERR_OK == err;
 }
 
 // Remove a folder recursively
 bool Adafruit_LittleFS::rmdir_r (char const *filepath)
 {
-  while (pdTRUE != xSemaphoreTake(_mutex,  portMAX_DELAY)) {}
-  bool retval = this->xWrap_rmdir_r(filepath);
-  xSemaphoreGive(_mutex);
-  return retval;
-}
-
-bool Adafruit_LittleFS::xWrap_rmdir_r (char const *filepath)
-{
   /* adafruit: lfs is modified to remove non-empty folder,
    According to below issue, comment these 2 line won't corrupt filesystem
-   https://github.com/ARMmbed/littlefs/issues/43 */
-  VERIFY_LFS(lfs_remove(&_lfs, filepath));
-  return true;
+   at least when using LFS v1.  If moving to LFS v2, see tracked issue
+   to see if issues (such as the orphans in threaded linked list) are resolved.
+   https://github.com/ARMmbed/littlefs/issues/43
+   */
+  xSemaphoreTake(_mutex,  portMAX_DELAY);
+  int err = lfs_remove(&_lfs, filepath);
+  PRINT_LFS_ERR(err);
+  xSemaphoreGive(_mutex);
+  return LFS_ERR_OK == err;
 }
 
 //------------- Debug -------------//

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
@@ -81,29 +81,17 @@ class Adafruit_LittleFS
     SemaphoreHandle_t _mutex;
 
   private:
-    StaticSemaphore_t xMutexStorageSpace;
-
-    // these wrapped functions are needed to simplify
-    // change to serialize access via a mutex, at least in part
-    // because the VERIFY_LFS() macro includes a return statement,
-    // which would otherwise exit the functions without releasing the mutex.
-    bool xWrap_begin(struct lfs_config * cfg = NULL);
-    void xWrap_end(void);
-    Adafruit_LittleFS_Namespace::File xWrap_open (char const *filename, uint8_t mode = Adafruit_LittleFS_Namespace::FILE_O_READ);
-    bool xWrap_exists (char const *filepath);
-    bool xWrap_mkdir (char const *filepath);
-    bool xWrap_remove (char const *filepath);
-    bool xWrap_rmdir (char const *filepath);
-    bool xWrap_rmdir_r (char const *filepath);
-    bool xWrap_format (void);
+    StaticSemaphore_t _MutexStorageSpace;
 };
 
 #if !CFG_DEBUG
   #define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, NULL)
   #define PRINT_LFS_ERR(_err)
 #else
-  #define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, dbg_strerr_lfs)
-  #define PRINT_LFS_ERR(_err)   VERIFY_MESS((long int)_err, dbg_strerr_lfs) // LFS_ERR are of type int, VERIFY_MESS expects long_int
+  #define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, NULL)
+  #define PRINT_LFS_ERR(_err)
+  //#define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, dbg_strerr_lfs)
+  //#define PRINT_LFS_ERR(_err)   do { if (_err) { VERIFY_MESS((long int)_err, dbg_strerr_lfs); } } while(0) // LFS_ERR are of type int, VERIFY_MESS expects long_int
 
   const char* dbg_strerr_lfs (int32_t err);
 #endif

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
@@ -88,10 +88,8 @@ class Adafruit_LittleFS
   #define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, NULL)
   #define PRINT_LFS_ERR(_err)
 #else
-  #define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, NULL)
-  #define PRINT_LFS_ERR(_err)
-  //#define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, dbg_strerr_lfs)
-  //#define PRINT_LFS_ERR(_err)   do { if (_err) { VERIFY_MESS((long int)_err, dbg_strerr_lfs); } } while(0) // LFS_ERR are of type int, VERIFY_MESS expects long_int
+  #define VERIFY_LFS(...)       _GET_3RD_ARG(__VA_ARGS__, VERIFY_ERR_2ARGS, VERIFY_ERR_1ARGS)(__VA_ARGS__, dbg_strerr_lfs)
+  #define PRINT_LFS_ERR(_err)   do { if (_err) { VERIFY_MESS((long int)_err, dbg_strerr_lfs); } } while(0) // LFS_ERR are of type int, VERIFY_MESS expects long_int
 
   const char* dbg_strerr_lfs (int32_t err);
 #endif

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
@@ -77,6 +77,9 @@ class Adafruit_LittleFS
     struct lfs_config* _lfs_cfg;
     lfs_t _lfs;
 
+    // these two functions need access to the private _mutex variable:
+    friend void Adafruit_LittleFS_Namespace::File::DoNotCallFromOutsideClass_LockFilesystem(void);
+    friend void Adafruit_LittleFS_Namespace::File::DoNotCallFromOutsideClass_UnlockFilesystem(void);
     //static_assert(configSUPPORT_STATIC_ALLOCATION == 1, "Currently only supports configuration with STATIC_ALLOCATION enabled");
     SemaphoreHandle_t _mutex;
 

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
@@ -78,8 +78,8 @@ class Adafruit_LittleFS
     lfs_t _lfs;
 
     // these two functions need access to the private _mutex variable:
-    friend void Adafruit_LittleFS_Namespace::File::DoNotCallFromOutsideClass_LockFilesystem(void);
-    friend void Adafruit_LittleFS_Namespace::File::DoNotCallFromOutsideClass_UnlockFilesystem(void);
+    friend void Adafruit_LittleFS_Namespace::File::_LockFilesystem(void);
+    friend void Adafruit_LittleFS_Namespace::File::_UnlockFilesystem(void);
     //static_assert(configSUPPORT_STATIC_ALLOCATION == 1, "Currently only supports configuration with STATIC_ALLOCATION enabled");
     SemaphoreHandle_t _mutex;
 

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -46,8 +46,19 @@ File::File (Adafruit_LittleFS &fs)
 File::File (char const *filename, uint8_t mode, Adafruit_LittleFS &fs)
  : File(fs)
 {
+  // public constructor calls public API open(), which will obtain the mutex
   this->open(filename, mode);
 }
+
+File::File (uint8_t differentiator, char const *filename, uint8_t mode, Adafruit_LittleFS &fs)
+ : File(fs)
+{
+  // private constructor calls private API _open(), which does NOT obtain the mutex
+  (void)differentiator;
+  this->_open(filename, mode);
+}
+
+
 
 bool File::_open_file (char const *filepath, uint8_t mode)
 {
@@ -99,12 +110,23 @@ bool File::_open_dir (char const *filepath)
   return true;
 }
 
+// TODO: wrap close() because it must be called by open()
+// TODO: wrap open() because it is called by openNextFile()
+
 bool File::open (char const *filepath, uint8_t mode)
+{
+  bool ret = false;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  ret = this->_open(filepath, mode);
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
+}
+bool File::_open (char const *filepath, uint8_t mode)
 {
   bool ret = false;
 
   // close if currently opened
-  if ( (*this) ) close();
+  if ( this->_isOpen() ) _close();
 
   struct lfs_info info;
   int rc = lfs_stat(_fs->getFS(), filepath, &info);
@@ -130,151 +152,260 @@ bool File::open (char const *filepath, uint8_t mode)
     char const* splash = strrchr(filepath, '/');
     strncpy(_name, splash ? (splash + 1) : filepath, LFS_NAME_MAX);
   }
-
   return ret;
 }
 
 size_t File::write (uint8_t ch)
 {
-  VERIFY(!_is_dir, 0);
   return write(&ch, 1);
 }
 
 size_t File::write (uint8_t const *buf, size_t size)
 {
-  VERIFY(!_is_dir, 0);
-
-  lfs_ssize_t wrcount = lfs_file_write(_fs->getFS(), _file, buf, size);
-  VERIFY(wrcount > 0, 0);
+  lfs_ssize_t wrcount = 0;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  if (!this->_is_dir)
+  {
+    wrcount = lfs_file_write(_fs->getFS(), _file, buf, size);
+    if (wrcount < 0)
+    {
+      wrcount = 0;
+    };
+  }
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
   return wrcount;
 }
 
 int File::read (void)
 {
-  VERIFY(!_is_dir, -1);
+  // this thin wrapper relies on called function to synchronize
+  int ret = -1;
   uint8_t ch;
-  return (read(&ch, 1) > 0) ? ch : -1;
+  if (read(&ch, 1) > 0)
+  {
+    ret = static_cast<int>(ch);
+  }
+  return ret;
 }
 
 int File::read (void *buf, uint16_t nbyte)
 {
-  VERIFY(!_is_dir, 0);
-  return lfs_file_read(_fs->getFS(), _file, buf, nbyte);
+  int ret = 0;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  if (!this->_is_dir)
+  {
+    ret = lfs_file_read(_fs->getFS(), _file, buf, nbyte);
+  }
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
 }
 
 int File::peek (void)
 {
-  VERIFY(!_is_dir, -1);
-
-  int ch = read();
-  uint32_t pos = position();
-  seek((pos > 0) ? (pos - 1) : 0);
-  return ch;
+  int ret = -1;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  if (!this->_is_dir)
+  {
+    uint32_t pos = lfs_file_tell(_fs->getFS(), _file);
+    uint8_t ch = 0;
+    if (lfs_file_read(_fs->getFS(), _file, &ch, 1) > 0)
+    {
+      ret = static_cast<int>(ch);
+    }
+    (void)lfs_file_seek(_fs->getFS(), _file, pos, LFS_SEEK_SET);
+  }
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
 }
 
 int File::available (void)
 {
-  return size() - position();
+  int ret = 0;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  if (!this->_is_dir)
+  {
+    uint32_t size = lfs_file_size(_fs->getFS(), _file);
+    uint32_t pos  = lfs_file_tell(_fs->getFS(), _file);
+    ret = size - pos;
+  }
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
 }
 
 bool File::seek (uint32_t pos)
 {
-  VERIFY(!_is_dir, false);
-  return lfs_file_seek(_fs->getFS(), _file, pos, LFS_SEEK_SET) >= 0;
+  bool ret = false;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  if (!this->_is_dir)
+  {
+    ret = lfs_file_seek(_fs->getFS(), _file, pos, LFS_SEEK_SET) >= 0;
+  }
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
 }
 
 uint32_t File::position (void)
 {
-  VERIFY(!_is_dir, 0);
-  return lfs_file_tell(_fs->getFS(), _file);
+  uint32_t ret = 0;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  if (!this->_is_dir)
+  {
+    ret = lfs_file_tell(_fs->getFS(), _file);
+  }
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
 }
 
 uint32_t File::size (void)
 {
-  VERIFY(!_is_dir, 0);
-  return lfs_file_size(_fs->getFS(), _file);
+  uint32_t ret = 0;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  if (!this->_is_dir)
+  {
+    ret = lfs_file_size(_fs->getFS(), _file);
+  }
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
+
 }
 
 void File::flush (void)
 {
-  VERIFY(!_is_dir,);
-  lfs_file_sync(_fs->getFS(), _file);
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  if (!this->_is_dir)
+  {
+    lfs_file_sync(_fs->getFS(), _file);
+  }
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return;
 }
 
 void File::close (void)
 {
-  if ( (*this) )
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_close();
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+}
+void File::_close(void)
+{
+  if ( this->_isOpen() )
   {
-    if ( _is_dir )
+    if ( this->_is_dir )
     {
       lfs_dir_close(_fs->getFS(), _dir);
       rtos_free(_dir);
       _dir = NULL;
 
-      if ( _dir_path ) rtos_free(_dir_path);
+      if ( this->_dir_path ) rtos_free(_dir_path);
       _dir_path = NULL;
     }
     else
     {
-      lfs_file_close(_fs->getFS(), _file);
+      lfs_file_close(this->_fs->getFS(), _file);
       rtos_free(_file);
       _file = NULL;
     }
   }
 }
 
+[[deprecated("Recommend use of isOpen() for clarity")]]
 File::operator bool (void)
+{
+  bool ret = false;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  ret = this->_isOpen();
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
+}
+bool File::isOpen(void)
+{
+  bool ret = 0;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  ret = this->_isOpen();
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
+}
+bool File::_isOpen(void)
 {
   return (_file != NULL) || (_dir != NULL);
 }
 
+// WARNING -- although marked as `const`, the values pointed
+//            to may change.  For example, if the same File
+//            object has `open()` called with a different
+//            file or directory name, this same pointer will
+//            suddenly (unexpectedly?) have different values.
 char const* File::name (void)
 {
-  return _name;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  char const* ret = this->_name;
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
 }
 
 bool File::isDirectory (void)
 {
-  return _is_dir;
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  bool ret = this->_is_dir;
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
+
 }
 
 File File::openNextFile (uint8_t mode)
 {
-  File file(*_fs);
+  this->DoNotCallFromOutsideClass_LockFilesystem();
 
-  if ( !_is_dir ) return file;
-
-  struct lfs_info info;
-
-  int rc;
-
-  // lfs_dir_read return 0 when reaching end of directory, 1 if found an entry
-  // skip "." and ".." entries
-  do
+  File ret(*_fs);
+  if (this->_is_dir)
   {
-    rc = lfs_dir_read(_fs->getFS(), _dir, &info);
-  } while ( rc == 1 && (!strcmp(".", info.name) || !strcmp("..", info.name)) );
+    struct lfs_info info;
+    int rc;
 
-  if ( rc == 1 )
-  {
-    // string cat name with current folder
-    char filepath[strlen(_dir_path) + 1 + strlen(info.name) + 1];
+    // lfs_dir_read returns 0 when reaching end of directory, 1 if found an entry
+    // Skip the "." and ".." entries ...
+    do
+    {
+      rc = lfs_dir_read(_fs->getFS(), _dir, &info);
+    } while ( rc == 1 && (!strcmp(".", info.name) || !strcmp("..", info.name)) );
 
-    strcpy(filepath, _dir_path);
-    if ( !(_dir_path[0] == '/' && _dir_path[1] == 0) ) strcat(filepath, "/");    // only add '/' if cwd is not root
-    strcat(filepath, info.name);
+    if ( rc == 1 )
+    {
+      // string cat name with current folder
+      char filepath[strlen(_dir_path) + 1 + strlen(info.name) + 1]; // potential for significant stack usage
+      strcpy(filepath, _dir_path);
+      if ( !(_dir_path[0] == '/' && _dir_path[1] == 0) ) strcat(filepath, "/");    // only add '/' if cwd is not root
+      strcat(filepath, info.name);
 
-    file.open(filepath, mode);
+      (void)ret._open(filepath, mode); // return value is ignored ... caller is expected to check isOpened()
+    }
+    else if ( rc < 0 )
+    {
+      PRINT_LFS_ERR(rc);
+    }
   }
-  else if ( rc < 0 )
-  {
-    PRINT_LFS_ERR(rc);
-  }
-
-  return file;
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return ret;
 }
 
 void File::rewindDirectory (void)
 {
-  VERIFY_LFS(lfs_dir_rewind(_fs->getFS(), _dir),);
+  this->DoNotCallFromOutsideClass_LockFilesystem();
+  if (this->_is_dir)
+  {
+    lfs_dir_rewind(_fs->getFS(), _dir);
+  }
+  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  return;
 }
+
+void File::DoNotCallFromOutsideClass_LockFilesystem(void)
+{
+  xSemaphoreTake(this->_fs->_mutex,  portMAX_DELAY);
+}
+void File::DoNotCallFromOutsideClass_UnlockFilesystem(void)
+{
+  xSemaphoreGive(this->_fs->_mutex);
+}
+
+

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -50,16 +50,6 @@ File::File (char const *filename, uint8_t mode, Adafruit_LittleFS &fs)
   this->open(filename, mode);
 }
 
-File::File (uint8_t differentiator, char const *filename, uint8_t mode, Adafruit_LittleFS &fs)
- : File(fs)
-{
-  // private constructor calls private API _open(), which does NOT obtain the mutex
-  (void)differentiator;
-  this->_open(filename, mode);
-}
-
-
-
 bool File::_open_file (char const *filepath, uint8_t mode)
 {
   int flags = (mode == FILE_O_READ) ? LFS_O_RDONLY :

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -110,9 +110,6 @@ bool File::_open_dir (char const *filepath)
   return true;
 }
 
-// TODO: wrap close() because it must be called by open()
-// TODO: wrap open() because it is called by openNextFile()
-
 bool File::open (char const *filepath, uint8_t mode)
 {
   bool ret = false;
@@ -308,7 +305,6 @@ void File::_close(void)
   }
 }
 
-[[deprecated("Recommend use of isOpen() for clarity")]]
 File::operator bool (void)
 {
   bool ret = false;

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -103,9 +103,9 @@ bool File::_open_dir (char const *filepath)
 bool File::open (char const *filepath, uint8_t mode)
 {
   bool ret = false;
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   ret = this->_open(filepath, mode);
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 }
 bool File::_open (char const *filepath, uint8_t mode)
@@ -150,7 +150,7 @@ size_t File::write (uint8_t ch)
 size_t File::write (uint8_t const *buf, size_t size)
 {
   lfs_ssize_t wrcount = 0;
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   if (!this->_is_dir)
   {
     wrcount = lfs_file_write(_fs->getFS(), _file, buf, size);
@@ -159,7 +159,7 @@ size_t File::write (uint8_t const *buf, size_t size)
       wrcount = 0;
     };
   }
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return wrcount;
 }
 
@@ -178,19 +178,19 @@ int File::read (void)
 int File::read (void *buf, uint16_t nbyte)
 {
   int ret = 0;
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   if (!this->_is_dir)
   {
     ret = lfs_file_read(_fs->getFS(), _file, buf, nbyte);
   }
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 }
 
 int File::peek (void)
 {
   int ret = -1;
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   if (!this->_is_dir)
   {
     uint32_t pos = lfs_file_tell(_fs->getFS(), _file);
@@ -201,77 +201,77 @@ int File::peek (void)
     }
     (void)lfs_file_seek(_fs->getFS(), _file, pos, LFS_SEEK_SET);
   }
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 }
 
 int File::available (void)
 {
   int ret = 0;
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   if (!this->_is_dir)
   {
     uint32_t size = lfs_file_size(_fs->getFS(), _file);
     uint32_t pos  = lfs_file_tell(_fs->getFS(), _file);
     ret = size - pos;
   }
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 }
 
 bool File::seek (uint32_t pos)
 {
   bool ret = false;
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   if (!this->_is_dir)
   {
     ret = lfs_file_seek(_fs->getFS(), _file, pos, LFS_SEEK_SET) >= 0;
   }
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 }
 
 uint32_t File::position (void)
 {
   uint32_t ret = 0;
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   if (!this->_is_dir)
   {
     ret = lfs_file_tell(_fs->getFS(), _file);
   }
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 }
 
 uint32_t File::size (void)
 {
   uint32_t ret = 0;
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   if (!this->_is_dir)
   {
     ret = lfs_file_size(_fs->getFS(), _file);
   }
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 
 }
 
 void File::flush (void)
 {
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   if (!this->_is_dir)
   {
     lfs_file_sync(_fs->getFS(), _file);
   }
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return;
 }
 
 void File::close (void)
 {
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   this->_close();
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
 }
 void File::_close(void)
 {
@@ -302,9 +302,9 @@ File::operator bool (void)
 bool File::isOpen(void)
 {
   bool ret = 0;
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   ret = this->_isOpen();
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 }
 bool File::_isOpen(void)
@@ -319,24 +319,24 @@ bool File::_isOpen(void)
 //            suddenly (unexpectedly?) have different values.
 char const* File::name (void)
 {
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   char const* ret = this->_name;
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 }
 
 bool File::isDirectory (void)
 {
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   bool ret = this->_is_dir;
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 
 }
 
 File File::openNextFile (uint8_t mode)
 {
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
 
   File ret(*_fs);
   if (this->_is_dir)
@@ -366,26 +366,26 @@ File File::openNextFile (uint8_t mode)
       PRINT_LFS_ERR(rc);
     }
   }
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return ret;
 }
 
 void File::rewindDirectory (void)
 {
-  this->DoNotCallFromOutsideClass_LockFilesystem();
+  this->_LockFilesystem();
   if (this->_is_dir)
   {
     lfs_dir_rewind(_fs->getFS(), _dir);
   }
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
+  this->_UnlockFilesystem();
   return;
 }
 
-void File::DoNotCallFromOutsideClass_LockFilesystem(void)
+void File::_LockFilesystem(void)
 {
   xSemaphoreTake(this->_fs->_mutex,  portMAX_DELAY);
 }
-void File::DoNotCallFromOutsideClass_UnlockFilesystem(void)
+void File::_UnlockFilesystem(void)
 {
   xSemaphoreGive(this->_fs->_mutex);
 }

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -297,11 +297,7 @@ void File::_close(void)
 
 File::operator bool (void)
 {
-  bool ret = false;
-  this->DoNotCallFromOutsideClass_LockFilesystem();
-  ret = this->_isOpen();
-  this->DoNotCallFromOutsideClass_UnlockFilesystem();
-  return ret;
+  return isOpen();
 }
 bool File::isOpen(void)
 {

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
@@ -76,7 +76,6 @@ class File : public Stream
 
     void close (void);
 
-    __attribute__((deprecated("Recommend use of isOpen() for clarity")))
     operator bool (void);
 
     bool isOpen(void);

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
@@ -82,8 +82,8 @@ class File : public Stream
     void rewindDirectory (void);
 
     // Has to be public, in order to grant 'friend' permissions to Adafruit_LittleFS private member _mutex
-    void DoNotCallFromOutsideClass_LockFilesystem(void);
-    void DoNotCallFromOutsideClass_UnlockFilesystem(void);
+    void _LockFilesystem(void);
+    void _UnlockFilesystem(void);
 
   private:
     Adafruit_LittleFS* _fs;

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
@@ -44,10 +44,6 @@ class File : public Stream
     File (Adafruit_LittleFS &fs);
     File (char const *filename, uint8_t mode, Adafruit_LittleFS &fs);
 
-  private:
-    // openNextFile() needs a constructor that does NOT take the mutex.
-    File (uint8_t differentiator, char const *filename, uint8_t mode, Adafruit_LittleFS &fs);
-
   public:
 
     bool open (char const *filename, uint8_t mode);

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
@@ -44,6 +44,12 @@ class File : public Stream
     File (Adafruit_LittleFS &fs);
     File (char const *filename, uint8_t mode, Adafruit_LittleFS &fs);
 
+  private:
+    // openNextFile() needs a constructor that does NOT take the mutex.
+    File (uint8_t differentiator, char const *filename, uint8_t mode, Adafruit_LittleFS &fs);
+
+  public:
+
     bool open (char const *filename, uint8_t mode);
 
     //------------- Stream API -------------//
@@ -69,12 +75,20 @@ class File : public Stream
     uint32_t size (void);
 
     void close (void);
+
+    __attribute__((deprecated("Recommend use of isOpen() for clarity")))
     operator bool (void);
+
+    bool isOpen(void);
     char const* name (void);
 
     bool isDirectory (void);
     File openNextFile (uint8_t mode = FILE_O_READ);
     void rewindDirectory (void);
+
+    // Has to be public, in order to grant 'friend' permissions to Adafruit_LittleFS private member _mutex
+    void DoNotCallFromOutsideClass_LockFilesystem(void);
+    void DoNotCallFromOutsideClass_UnlockFilesystem(void);
 
   private:
     Adafruit_LittleFS* _fs;
@@ -89,8 +103,11 @@ class File : public Stream
     char* _dir_path;
     char  _name[LFS_NAME_MAX+1];
 
+    bool _open(char const *filepath, uint8_t mode);
     bool _open_file(char const *filepath, uint8_t mode);
     bool _open_dir (char const *filepath);
+    void _close(void);
+    bool _isOpen(void);
 };
 
 }

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -28,7 +28,7 @@ using namespace Adafruit_LittleFS_Namespace;
  */
 
 // timeout in seconds
-#define TIME_OUT      60
+#define TIME_OUT        60
 
 // Limit number of writes since our internal flash is limited (28 KB in total)
 #define WRITE_COUNT   2000

--- a/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
+++ b/libraries/InternalFileSytem/examples/Internal_StressTest/Internal_StressTest.ino
@@ -1,0 +1,173 @@
+/*********************************************************************
+ This is an example for our nRF52 based Bluefruit LE modules
+
+ Pick one up today in the adafruit shop!
+
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
+
+#include <Adafruit_LittleFS.h>
+#include <InternalFileSystem.h>
+
+// hardware random generator
+#include "nrf_rng.h"
+
+using namespace Adafruit_LittleFS_Namespace;
+
+/* This example perform a stress test on Little FileSystem on internal flash.
+ * There are 4 different thread sharing same loop() code with different priority
+ *    loop (low), normal, high, highest
+ * Each will open and write a file of its name (+ .txt). Task takes turn writing until timeout
+ * to print out the summary
+ */
+
+// timeout in seconds
+#define TIME_OUT      60
+
+// Limit number of writes since our internal flash is limited (28 KB in total)
+#define WRITE_COUNT   2000
+
+uint32_t writeCount = 0;
+
+// the setup function runs once when you press reset or power the board
+void setup() 
+{
+  Serial.begin(115200);
+  while ( !Serial ) yield();   // for nrf52840 with native usb
+
+  Serial.println("Internal Stress Test Example");
+  yield();
+
+  // Initialize Internal File System
+  InternalFS.begin();
+
+  // Format
+  Serial.print("Formatting ... "); Serial.flush();
+  InternalFS.format();
+  Serial.println("Done"); Serial.flush();
+
+  // Create a folder for each thread
+  InternalFS.mkdir("high");
+  InternalFS.mkdir("n1");
+  InternalFS.mkdir("n2");
+  InternalFS.mkdir("n3");
+  InternalFS.mkdir("loop");
+
+  // Create thread with different priority
+  // Although all the thread share loop() code, they are separated threads
+  // and running with different priorities
+
+  // Note: default loop() is running at LOW
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_HIGH  , "high");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "n1");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "n2");
+  Scheduler.startLoop(loop, 1024, TASK_PRIO_NORMAL, "n3");
+}
+
+void write_files(const char * name)
+{
+  char fname[30] = { 0 };
+  sprintf(fname, "%s/%s.txt", name, name); // each task has its own folder and file
+
+  File file(InternalFS);
+
+  if ( file.open(fname, FILE_O_WRITE) )
+  {
+    file.printf("%d\n", writeCount++);
+    file.close();
+  }else
+  {
+    Serial.printf("Failed to open %s\n", fname);
+  }
+}
+
+void list_files(void)
+{
+  File root("/", FILE_O_READ, InternalFS);
+  File subdir(InternalFS);
+  File file(InternalFS);
+
+  while( (subdir = root.openNextFile(FILE_O_READ)) )
+  {
+    if ( subdir.isDirectory() )
+    {
+      char fname[30];
+      sprintf(fname, "%s/%s.txt", subdir.name(), subdir.name());
+
+      if ( file.open(fname, FILE_O_READ) )
+      {
+        Serial.printf("--- %s ---\n", fname);
+
+        while ( file.available() )
+        {
+          char buffer[64] = { 0 };
+          file.read(buffer, sizeof(buffer)-1);
+
+          Serial.print(buffer);
+          delay(10);
+        }
+        file.close();
+
+        Serial.println("---------------\n");
+      }
+    }
+
+    subdir.close();
+  }
+}
+
+// Use random generator (requires Softdevice disabled)
+uint16_t get_rand(void)
+{
+  uint8_t bytes[2];
+
+  for(int i=0; i<2; i++)
+  {
+    nrf_rng_event_clear(NRF_RNG_EVENT_VALRDY);
+    nrf_rng_task_trigger(NRF_RNG_TASK_START);
+
+    while ( !nrf_rng_event_get(NRF_RNG_EVENT_VALRDY) ) yield();
+
+    bytes[i] = nrf_rng_random_value_get();
+  }
+
+  return (bytes[0] << 8) + bytes[1];
+}
+
+// the loop function runs over and over again forever
+void loop() 
+{
+  TaskHandle_t th = xTaskGetCurrentTaskHandle();
+
+  if ( (millis() > TIME_OUT*1000) || (writeCount > WRITE_COUNT) )
+  {
+    // low priority task print summary
+    if (TASK_PRIO_LOW == uxTaskPriorityGet(th))
+    {
+      Serial.printf("Total write count = %d in %.2f seconds\n", writeCount, millis()/1000.0);
+      list_files();
+    }
+
+    delay(1000);
+    vTaskSuspend(NULL); // suspend task
+    return;
+  }
+
+  const char* name = pcTaskGetName(th);
+  Serial.printf( "Task %s writing ...\n", name );
+  Serial.flush();
+
+  // Write files
+  write_files(name);
+
+  // lower delay increase chance for high prio task preempt others.
+  // delay is from 0-5000
+  uint16_t ms = get_rand() % 5000;
+  delay(ms);
+}


### PR DESCRIPTION
Fix #350
Fix #325
Fix #227
Fix #222
Fix #393

@hathach -- This PR supercedes #372 (Guard against race conditions in Flash FS cache), as #72 was not really providing a proper fix of the underlying problem:

LFS itself is [not safe](https://github.com/ARMmbed/littlefs/issues/352) to call simultaneously from multiple contexts.

This PR solves this by wrapping the InternalFS API with a non-recursive mutex, as recommended.

I realize the PR uses newly declared wrapper functions.  I tried to avoid this, but the changes got messy quite quickly, mostly due to some of the macros used to verify return codes exiting the function (which would leak the mutex).  This is a reasonably clean solution, without the more drastic move to use of RAII objects such as [`std::lock_guard<>`](https://en.cppreference.com/w/cpp/thread/lock_guard).