### PR TITLE
Fix wrong expression of device ID in getMcuUniqueID()

### DIFF
--- a/cores/nRF5/utility/utilities.c
+++ b/cores/nRF5/utility/utilities.c
@@ -93,7 +93,7 @@ const char* getMcuUniqueID(void)
   // Skip if already created
   if ( serial_str[0] == 0 )
   {
-    sprintf(serial_str, "%08lu%08lu", NRF_FICR->DEVICEID[1], NRF_FICR->DEVICEID[0]);
+    sprintf(serial_str, "%08lX%08lX", NRF_FICR->DEVICEID[1], NRF_FICR->DEVICEID[0]);
   }
 
   return serial_str;


### PR DESCRIPTION
Recently modified device ID expression ("%08lX%08lX" -> "%08lu%08lu") incurs system hanging in release build and reset in debug build.
Revert to hex expression solves the problem.