### PR TITLE
Xenon Support: Removed LED pin 22

### DIFF
--- a/variants/particle_xenon/variant.cpp
+++ b/variants/particle_xenon/variant.cpp
@@ -53,7 +53,6 @@ const uint32_t g_ADigitalPinMap[] =
   _PINNUM(0, 18),   // P0.18 (RESET)
 
   // LEDS
-  _PINNUM(1, 12),   // P1.12 (PRIMARY_LED)
   _PINNUM(0, 13),   // P0.13 (RGB_RED)
   _PINNUM(0, 14),   // P0.14 (RGB_GREEN)
   _PINNUM(0, 15),   // P0.15 (RGB_BLUE) 

--- a/variants/particle_xenon/variant.h
+++ b/variants/particle_xenon/variant.h
@@ -104,9 +104,9 @@ static const uint8_t D20 = PIN_D20;
 #define LED_RED              PIN_LED1
 #define LED_BLUE             PIN_LED1
 
-static const uint8_t LED_RGB_RED   = (23);
-static const uint8_t LED_RGB_GREEN = (24);
-static const uint8_t LED_RGB_BLUE  = (25);
+static const uint8_t LED_RGB_RED   = (22);
+static const uint8_t LED_RGB_GREEN = (23);
+static const uint8_t LED_RGB_BLUE  = (24);
 
 // Buttons
 #define BUTTONS_NUMBER 2
@@ -117,24 +117,24 @@ static const uint8_t LED_RGB_BLUE  = (25);
 static const uint8_t BUTTON_MODE =  (20);
 
 // Antenna
-#define ANTENNA_SWITCH_1            (26)
-#define ANTENNA_SWITCH_2            (27)
+#define ANTENNA_SWITCH_1            (25)
+#define ANTENNA_SWITCH_2            (26)
 
 // NFC
-#define NFC1                        (28)
-#define NFC2                        (29)
+#define NFC1                        (27)
+#define NFC2                        (28)
 
 /*
  * Analog pins
  */
-#define PIN_A0                      (30)
-#define PIN_A1                      (31)
-#define PIN_A2                      (32)
-#define PIN_A3                      (33)
-#define PIN_A4                      (34)
-#define PIN_A5                      (35)
-#define PIN_A6                      (36)
-#define PIN_A7                      (37)
+#define PIN_A0                      (29)
+#define PIN_A1                      (30)
+#define PIN_A2                      (31)
+#define PIN_A3                      (32)
+#define PIN_A4                      (33)
+#define PIN_A5                      (34)
+#define PIN_A6                      (35)
+#define PIN_A7                      (36)
 
 static const uint8_t A0 = PIN_A0;
 static const uint8_t A1 = PIN_A1;

--- a/variants/particle_xenon/variant.h
+++ b/variants/particle_xenon/variant.h
@@ -97,7 +97,7 @@ static const uint8_t D20 = PIN_D20;
 
 #define BOARD_RGB_BRIGHTNESS 0x202020
 
-#define PIN_LED1             (22)
+#define PIN_LED1             (7)
 #define LED_BUILTIN          PIN_LED1
 #define LED_CONN             PIN_LED1
 


### PR DESCRIPTION
Removed duplicate pin mapping for the PRIMARY LED. Moved up all other pin mappings to account for the removed one.