### PR TITLE
[WIP] Groundwork for debug output improvements

### DIFF
--- a/cores/nRF5/common_func.h
+++ b/cores/nRF5/common_func.h
@@ -142,7 +142,7 @@ const char* dbg_err_str(int32_t err_id); // TODO move to other place
 
 #define PRINT_LOCATION()      PRINTF("%s: %d:\n", __PRETTY_FUNCTION__, __LINE__)
 #define PRINT_MESS(x)         PRINTF("%s: %d: %s \n"   , __FUNCTION__, __LINE__, (char*)(x))
-#define PRTNT_HEAP()          if (CFG_DEBUG == 3) PRINTF("\n%s: %d: Heap free: %d\n", __FUNCTION__, __LINE__, util_heap_get_free_size())
+#define PRTNT_HEAP()          if (CFG_DEBUG >= 3) PRINTF("\n%s: %d: Heap free: %d\n", __FUNCTION__, __LINE__, util_heap_get_free_size())
 #define PRINT_STR(x)          PRINTF("%s: %d: " #x " = %s\n"   , __FUNCTION__, __LINE__, (char*)(x) )
 #define PRINT_INT(x)          PRINTF("%s: %d: " #x " = %ld\n"  , __FUNCTION__, __LINE__, (uint32_t) (x) )
 #define PRINT_FLOAT(x)        PRINTF("%s: %d: " #x " = %f\n"  , __FUNCTION__, __LINE__, (float) (x) )

--- a/cores/nRF5/common_func.h
+++ b/cores/nRF5/common_func.h
@@ -116,6 +116,13 @@
 //--------------------------------------------------------------------+
 const char* dbg_err_str(int32_t err_id); // TODO move to other place
 
+#if __cplusplus
+#define PRINTF    ::printf
+#else
+#define PRINTF    printf
+#endif
+
+
 #if CFG_DEBUG
 #define LOG_LV1(...)          ADALOG(__VA_ARGS__)
 #define LOG_LV1_BUFFER(...)   ADALOG_BUFFER(__VA_ARGS__)
@@ -133,12 +140,6 @@ const char* dbg_err_str(int32_t err_id); // TODO move to other place
 #endif
 
 #if CFG_DEBUG
-
-#if __cplusplus
-#define PRINTF    ::printf
-#else
-#define PRINTF    printf
-#endif
 
 #define PRINT_LOCATION()      PRINTF("%s: %d:\n", __PRETTY_FUNCTION__, __LINE__)
 #define PRINT_MESS(x)         PRINTF("%s: %d: %s \n"   , __FUNCTION__, __LINE__, (char*)(x))

--- a/cores/nRF5/utility/debug.cpp
+++ b/cores/nRF5/utility/debug.cpp
@@ -39,6 +39,7 @@
 #include <malloc.h>
 #include <Arduino.h>
 #include <ctype.h>
+#include <common_func.h>
 
 // defined in linker script
 extern uint32_t __data_start__[];

--- a/cores/nRF5/utility/debug.cpp
+++ b/cores/nRF5/utility/debug.cpp
@@ -106,14 +106,14 @@ static void printMemRegion(const char* name, uint32_t top, uint32_t bottom, uint
     sprintf(buffer, "%lu", top-bottom);
   }
 
-  printf("| %-5s| 0x%04X - 0x%04X | %-19s |\n", name, (uint16_t) bottom, (uint16_t) (top-1), buffer);
+  PRINTF("| %-5s| 0x%04X - 0x%04X | %-19s |\n", name, (uint16_t) bottom, (uint16_t) (top-1), buffer);
 }
 
 void dbgMemInfo(void)
 {
-  printf(" ______________________________________________\n");
-  printf("| Name | Addr 0x2000xxxx | Usage               |\n");
-  printf("| ---------------------------------------------|\n");
+  PRINTF(" ______________________________________________\n");
+  PRINTF("| Name | Addr 0x2000xxxx | Usage               |\n");
+  PRINTF("| ---------------------------------------------|\n");
 
   // Pritn SRAM used for Stack executed by Softdevice and ISR
   printMemRegion("Stack", ((uint32_t) __StackTop), ((uint32_t) __StackLimit), dbgStackUsed() );
@@ -127,8 +127,8 @@ void dbgMemInfo(void)
   // Print SRAM Used by SoftDevice
   printMemRegion("SD", (uint32_t) __data_start__, 0x20000000, 0);
 
-  printf("|______________________________________________|\n");
-  printf("\n");
+  PRINTF("|______________________________________________|\n");
+  PRINTF("\n");
 
   // Print Task list
   uint32_t tasknum = uxTaskGetNumberOfTasks();
@@ -136,20 +136,20 @@ void dbgMemInfo(void)
 
   vTaskList(buf);
 
-  printf("Task    State   Prio  StackLeft Num\n");
-  printf("-----------------------------------\n");
-  printf(buf);
-  printf("\n");
+  PRINTF("Task    State   Prio  StackLeft Num\n");
+  PRINTF("-----------------------------------\n");
+  PRINTF(buf);
+  PRINTF("\n");
   rtos_free(buf);
 }
 
 void dbgPrintVersion(void)
 {
-  printf("\n");
-  printf("BSP Library : " ARDUINO_BSP_VERSION "\n");
-  printf("Bootloader  : %s\n", getBootloaderVersion());
-  printf("Serial No   : %s\n", getMcuUniqueID());
-  printf("\n");
+  PRINTF("\n");
+  PRINTF("BSP Library : " ARDUINO_BSP_VERSION "\n");
+  PRINTF("Bootloader  : %s\n", getBootloaderVersion());
+  PRINTF("Serial No   : %s\n", getMcuUniqueID());
+  PRINTF("\n");
 }
 
 /******************************************************************************/
@@ -163,7 +163,7 @@ static void dump_str_line(uint8_t const* buf, uint16_t count)
   for(int i=0; i<count; i++)
   {
     const char ch = buf[i];
-    printf("%c", isprint(ch) ? ch : '.');
+    PRINTF("%c", isprint(ch) ? ch : '.');
   }
 }
 
@@ -171,7 +171,7 @@ void dbgDumpMemory(void const *buf, uint8_t size, uint16_t count, bool printOffs
 {
   if ( !buf || !count )
   {
-    printf("NULL\n");
+    PRINTF("NULL\n");
     return;
   }
 
@@ -191,26 +191,26 @@ void dbgDumpMemory(void const *buf, uint8_t size, uint16_t count, bool printOffs
       // Print Ascii
       if ( i != 0 )
       {
-        printf(" | ");
+        PRINTF(" | ");
         dump_str_line(buf8-16, 16);
-        printf("\n");
+        PRINTF("\n");
       }
 
       // print offset or absolute address
       if (printOffset)
       {
-        printf("%03lX: ", 16*i/item_per_line);
+        PRINTF("%03lX: ", 16*i/item_per_line);
       }else
       {
-        printf("%08lX:", (uint32_t) buf8);
+        PRINTF("%08lX:", (uint32_t) buf8);
       }
     }
 
     memcpy(&value, buf8, size);
     buf8 += size;
 
-    printf(" ");
-    printf(format, value);
+    PRINTF(" ");
+    PRINTF(format, value);
   }
 
   // fill up last row to 16 for printing ascii
@@ -221,16 +221,16 @@ void dbgDumpMemory(void const *buf, uint8_t size, uint16_t count, bool printOffs
   {
     for(int i=0; i< 16-remain; i++)
     {
-      printf(" ");
-      for(int j=0; j<2*size; j++) printf(" ");
+      PRINTF(" ");
+      for(int j=0; j<2*size; j++) PRINTF(" ");
     }
   }
 
-  printf(" | ");
+  PRINTF(" | ");
   dump_str_line(buf8-nback, nback);
-  printf("\n");
+  PRINTF("\n");
 
-  printf("\n");
+  PRINTF("\n");
 }
 
 
@@ -238,11 +238,11 @@ void dbgDumpMemoryCFormat(const char* str, void const *buf, uint16_t count)
 {
   if ( !buf )
   {
-    printf("NULL\n");
+    PRINTF("NULL\n");
     return;
   }
 
-  printf("%s = \n{\n  ", str);
+  PRINTF("%s = \n{\n  ", str);
 
   uint8_t const *buf8 = (uint8_t const *) buf;
 
@@ -250,17 +250,17 @@ void dbgDumpMemoryCFormat(const char* str, void const *buf, uint16_t count)
   {
     if ( i%16 == 0 )
     {
-      if ( i != 0 ) printf(",\n  ");
+      if ( i != 0 ) PRINTF(",\n  ");
     }else
     {
-      if ( i != 0 ) printf(", ");
+      if ( i != 0 ) PRINTF(", ");
     }
 
-    printf("0x%02X", *buf8);
+    PRINTF("0x%02X", *buf8);
     buf8++;
   }
 
-  printf("\n};\n");
+  PRINTF("\n};\n");
 }
 
 

--- a/cores/nRF5/verify.h
+++ b/cores/nRF5/verify.h
@@ -60,16 +60,16 @@ extern "C"
   #define VERIFY_MESS(_status, _functstr) VERIFY_MESS_impl(_status, _functstr, __PRETTY_FUNCTION__, __LINE__)
   static inline void VERIFY_MESS_impl(int32_t _status, const char* (*_fstr)(int32_t), const char* func_name, int line_number)
   {
-      printf("%s: %d: verify failed, error = ", func_name, line_number);
+      PRINTF("%s: %d: verify failed, error = ", func_name, line_number);
       if (_fstr)
       {
-        printf(_fstr(_status));
+        PRINTF(_fstr(_status));
       }
       else
       {
-        printf("%ld", _status);
+        PRINTF("%ld", _status);
       }
-      printf("\n");
+      PRINTF("\n");
   }
 #else
   #define VERIFY_MESS(_status, _funcstr)

--- a/libraries/Adafruit_LittleFS/src/littlefs/lfs_util.h
+++ b/libraries/Adafruit_LittleFS/src/littlefs/lfs_util.h
@@ -56,21 +56,21 @@ extern "C"
 // Logging functions
 #ifndef LFS_NO_DEBUG
 #define LFS_DEBUG(fmt, ...) \
-    printf("lfs debug:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+    PRINTF("lfs debug:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else
 #define LFS_DEBUG(fmt, ...)
 #endif
 
 #ifndef LFS_NO_WARN
 #define LFS_WARN(fmt, ...) \
-    printf("lfs warn:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+    PRINTF("lfs warn:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else
 #define LFS_WARN(fmt, ...)
 #endif
 
 #ifndef LFS_NO_ERROR
 #define LFS_ERROR(fmt, ...) \
-    printf("lfs error:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+    PRINTF("lfs error:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else
 #define LFS_ERROR(fmt, ...)
 #endif

--- a/libraries/BLEAdafruitService/src/services/BLEAdafruitQuaternion.cpp
+++ b/libraries/BLEAdafruitService/src/services/BLEAdafruitQuaternion.cpp
@@ -134,7 +134,9 @@ void BLEAdafruitQuaternion::_update_timer(int32_t ms)
 #if CFG_DEBUG
 static void print_quaternion(float quater[4])
 {
-  Serial.printf("Quaternion: %.04f, %.04f, %.04f, %.04f\n", quater[0], quater[1], quater[2], quater[3]);
+  // prepare for ability to change output, based on compile-time flags
+  Print& logger = Serial;
+  logger.printf("Quaternion: %.04f, %.04f, %.04f, %.04f\n", quater[0], quater[1], quater[2], quater[3]);
 }
 #endif
 

--- a/libraries/Bluefruit52Lib/src/BLEPeriph.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEPeriph.cpp
@@ -151,14 +151,16 @@ void BLEPeriph::_eventHandler(ble_evt_t* evt)
 void BLEPeriph::printInfo(void)
 {
   char const * title_fmt = "%-16s: ";
+  // prepare for ability to change output, based on compile-time flags
+  Print& logger = Serial;
 
-  Serial.printf(title_fmt, "Conn Intervals");
-  Serial.printf("min = %.2f ms, ", _ppcp.min_conn_interval*1.25f);
-  Serial.printf("max = %.2f ms", _ppcp.max_conn_interval*1.25f);
-  Serial.println();
+  logger.printf(title_fmt, "Conn Intervals");
+  logger.printf("min = %.2f ms, ", _ppcp.min_conn_interval*1.25f);
+  logger.printf("max = %.2f ms", _ppcp.max_conn_interval*1.25f);
+  logger.println();
 
-  Serial.printf(title_fmt, "Conn Timeout");
-  Serial.printf("%d ms", _ppcp.conn_sup_timeout*10);
-  Serial.println();
+  logger.printf(title_fmt, "Conn Timeout");
+  logger.printf("%d ms", _ppcp.conn_sup_timeout*10);
+  logger.println();
 }
 

--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -971,120 +971,122 @@ void AdafruitBluefruit::printInfo(void)
 {
   // Skip if Serial is not initialised
   if ( !Serial ) return;
+  // prepare for ability to change output, based on compile-time flags
+  Print& logger = Serial;
 
   // Skip if Bluefruit.begin() is not called
   if ( _ble_event_sem == NULL ) return;
 
-  Serial.println("--------- SoftDevice Config ---------");
+  logger.println("--------- SoftDevice Config ---------");
 
   char const * title_fmt = "%-16s: ";
 
   /*------------- SoftDevice Config -------------*/
   // Max uuid128
-  Serial.printf(title_fmt, "Max UUID128");
-  Serial.println(_sd_cfg.uuid128_max);
+  logger.printf(title_fmt, "Max UUID128");
+  logger.println(_sd_cfg.uuid128_max);
 
   // ATTR Table Size
-  Serial.printf(title_fmt, "ATTR Table Size");
-  Serial.println(_sd_cfg.attr_table_size);
+  logger.printf(title_fmt, "ATTR Table Size");
+  logger.println(_sd_cfg.attr_table_size);
 
   // Service Changed
-  Serial.printf(title_fmt, "Service Changed");
-  Serial.println(_sd_cfg.service_changed);
+  logger.printf(title_fmt, "Service Changed");
+  logger.println(_sd_cfg.service_changed);
 
   if ( _prph_count )
   {
-    Serial.println("Peripheral Connect Setting");
+    logger.println("Peripheral Connect Setting");
 
-    Serial.print("  - ");
-    Serial.printf(title_fmt, "Max MTU");
-    Serial.println(_sd_cfg.prph.mtu_max);
+    logger.print("  - ");
+    logger.printf(title_fmt, "Max MTU");
+    logger.println(_sd_cfg.prph.mtu_max);
 
-    Serial.print("  - ");
-    Serial.printf(title_fmt, "Event Length");
-    Serial.println(_sd_cfg.prph.event_len);
+    logger.print("  - ");
+    logger.printf(title_fmt, "Event Length");
+    logger.println(_sd_cfg.prph.event_len);
 
-    Serial.print("  - ");
-    Serial.printf(title_fmt, "HVN Queue Size");
-    Serial.println(_sd_cfg.prph.hvn_qsize);
+    logger.print("  - ");
+    logger.printf(title_fmt, "HVN Queue Size");
+    logger.println(_sd_cfg.prph.hvn_qsize);
 
-    Serial.print("  - ");
-    Serial.printf(title_fmt, "WrCmd Queue Size");
-    Serial.println(_sd_cfg.prph.wrcmd_qsize);
+    logger.print("  - ");
+    logger.printf(title_fmt, "WrCmd Queue Size");
+    logger.println(_sd_cfg.prph.wrcmd_qsize);
   }
 
   if ( _central_count )
   {
-    Serial.println("Central Connect Setting");
+    logger.println("Central Connect Setting");
 
-    Serial.print("  - ");
-    Serial.printf(title_fmt, "Max MTU");
-    Serial.println(_sd_cfg.central.mtu_max);
+    logger.print("  - ");
+    logger.printf(title_fmt, "Max MTU");
+    logger.println(_sd_cfg.central.mtu_max);
 
-    Serial.print("  - ");
-    Serial.printf(title_fmt, "Event Length");
-    Serial.println(_sd_cfg.central.event_len);
+    logger.print("  - ");
+    logger.printf(title_fmt, "Event Length");
+    logger.println(_sd_cfg.central.event_len);
 
-    Serial.print("  - ");
-    Serial.printf(title_fmt, "HVN Queue Size");
-    Serial.println(_sd_cfg.central.hvn_qsize);
+    logger.print("  - ");
+    logger.printf(title_fmt, "HVN Queue Size");
+    logger.println(_sd_cfg.central.hvn_qsize);
 
-    Serial.print("  - ");
-    Serial.printf(title_fmt, "WrCmd Queue Size");
-    Serial.println(_sd_cfg.central.wrcmd_qsize);
+    logger.print("  - ");
+    logger.printf(title_fmt, "WrCmd Queue Size");
+    logger.println(_sd_cfg.central.wrcmd_qsize);
   }
 
   /*------------- Settings -------------*/
-  Serial.println("\n--------- BLE Settings ---------");
+  logger.println("\n--------- BLE Settings ---------");
   // Name
-  Serial.printf(title_fmt, "Name");
+  logger.printf(title_fmt, "Name");
   {
     char name[32];
     memclr(name, sizeof(name));
     getName(name, sizeof(name));
-    Serial.printf(name);
+    logger.printf(name);
   }
-  Serial.println();
+  logger.println();
 
   // Max Connections
-  Serial.printf(title_fmt, "Max Connections");
-  Serial.printf("Peripheral = %d, ", _prph_count);
-  Serial.printf("Central = %d ", _central_count);
-  Serial.println();
+  logger.printf(title_fmt, "Max Connections");
+  logger.printf("Peripheral = %d, ", _prph_count);
+  logger.printf("Central = %d ", _central_count);
+  logger.println();
 
   // Address
-  Serial.printf(title_fmt, "Address");
+  logger.printf(title_fmt, "Address");
   {
     char const * type_str[] = { "Public", "Static", "Private Resolvable", "Private Non Resolvable" };
     ble_gap_addr_t gap_addr = this->getAddr();
 
     // MAC is in little endian --> print reverse
-    Serial.printBufferReverse(gap_addr.addr, 6, ':');
-    Serial.printf(" (%s)", type_str[gap_addr.addr_type]);
+    logger.printBufferReverse(gap_addr.addr, 6, ':');
+    logger.printf(" (%s)", type_str[gap_addr.addr_type]);
   }
-  Serial.println();
+  logger.println();
 
   // Tx Power
-  Serial.printf(title_fmt, "TX Power");
-  Serial.printf("%d dBm", _tx_power);
-  Serial.println();
+  logger.printf(title_fmt, "TX Power");
+  logger.printf("%d dBm", _tx_power);
+  logger.println();
 
-  Periph.printInfo();
+  logger.printInfo();
 
   /*------------- List the paried device -------------*/
   if ( _prph_count )
   {
-    Serial.printf(title_fmt, "Peripheral Paired Devices");
-    Serial.println();
+    logger.printf(title_fmt, "Peripheral Paired Devices");
+    logger.println();
     bond_print_list(BLE_GAP_ROLE_PERIPH);
   }
 
   if ( _central_count )
   {
-    Serial.printf(title_fmt, "Central Paired Devices");
-    Serial.println();
+    logger.printf(title_fmt, "Central Paired Devices");
+    logger.println();
     bond_print_list(BLE_GAP_ROLE_CENTRAL);
   }
 
-  Serial.println();
+  logger.println();
 }

--- a/platform.txt
+++ b/platform.txt
@@ -56,8 +56,9 @@ build.debug_flags=-DCFG_DEBUG=0
 rtos.path={build.core.path}/freertos
 nordic.path={build.core.path}/nordic
 
-
-build.flags.nrf= -DSOFTDEVICE_PRESENT -DARDUINO_NRF52_ADAFRUIT -DNRF52_SERIES -DLFS_NAME_MAX=64 -Ofast {build.debug_flags} "-I{build.core.path}/cmsis/include" "-I{nordic.path}" "-I{nordic.path}/nrfx" "-I{nordic.path}/nrfx/hal" "-I{nordic.path}/nrfx/mdk" "-I{nordic.path}/nrfx/soc" "-I{nordic.path}/nrfx/drivers/include" "-I{nordic.path}/nrfx/drivers/src" "-I{nordic.path}/softdevice/{build.sd_name}_nrf52_{build.sd_version}_API/include" "-I{rtos.path}/Source/include" "-I{rtos.path}/config" "-I{rtos.path}/portable/GCC/nrf52" "-I{rtos.path}/portable/CMSIS/nrf52" "-I{build.core.path}/sysview/SEGGER" "-I{build.core.path}/sysview/Config" "-I{build.core.path}/TinyUSB" "-I{build.core.path}/TinyUSB/Adafruit_TinyUSB_ArduinoCore" "-I{build.core.path}/TinyUSB/Adafruit_TinyUSB_ArduinoCore/tinyusb/src"
+# build.logger_flags and build.sysview_flags and intentionally empty,
+# to allow modification via a user's own boards.local.txt or platform.local.txt files.
+build.flags.nrf= -DSOFTDEVICE_PRESENT -DARDUINO_NRF52_ADAFRUIT -DNRF52_SERIES -DLFS_NAME_MAX=64 -Ofast {build.debug_flags} {build.logger_flags} {build.sysview_flags} "-I{build.core.path}/cmsis/include" "-I{nordic.path}" "-I{nordic.path}/nrfx" "-I{nordic.path}/nrfx/hal" "-I{nordic.path}/nrfx/mdk" "-I{nordic.path}/nrfx/soc" "-I{nordic.path}/nrfx/drivers/include" "-I{nordic.path}/nrfx/drivers/src" "-I{nordic.path}/softdevice/{build.sd_name}_nrf52_{build.sd_version}_API/include" "-I{rtos.path}/Source/include" "-I{rtos.path}/config" "-I{rtos.path}/portable/GCC/nrf52" "-I{rtos.path}/portable/CMSIS/nrf52" "-I{build.core.path}/sysview/SEGGER" "-I{build.core.path}/sysview/Config" "-I{build.core.path}/TinyUSB" "-I{build.core.path}/TinyUSB/Adafruit_TinyUSB_ArduinoCore" "-I{build.core.path}/TinyUSB/Adafruit_TinyUSB_ArduinoCore/tinyusb/src"
 
 # usb flags
 build.flags.usb= -DUSBCON -DUSE_TINYUSB -DUSB_VID={build.vid} -DUSB_PID={build.pid} '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT={build.usb_product}'


### PR DESCRIPTION
This should be an easy PR to review.

### Important bits:

1. use uppercase PRINTF throughout the depot, rather than lowercase PRINTF.  This enables later (higher-performance) hook at the PRINTF level, rather than per-character _write() level.
2. For output previously going out through `Serial.print` and `Serial.println`, convert the code to use a reference to a `Print` class object (which `Serial` derives from).

### Useful info
I have compiled from commit 569b9b2 (was Adafruit master a few days ago) and from this PR's head (commit 1dcefd7), both at debug level 0 and 3.  I then analyzed the binaries using Ghidra and BinDiff, which validated that this PR does not change the compiled code.

### Note
This work is **_NOT_** limited to use only with Segger RTT, although that is definitely the first target.  Rather the longer target is to enable simple redirection of debug output,  to any object that supports the `Print` class.

This PR is a pre-requisite to enabling alternate debug output, such as Segger RTT, but also could be any other object that derives from the `Print` class (e.g., alternative serial port, alternative debugging output, TFT, LCD, etc.)
