### PR TITLE
partial revert PRITNF in lfs_util.h due to compilation error

### DIFF
--- a/cores/nRF5/common_inc.h
+++ b/cores/nRF5/common_inc.h
@@ -40,7 +40,7 @@
 #include <stdbool.h>
 
 #include "compiler_macro.h"
-#include "verify.h"
 #include "common_func.h"
+#include "verify.h"
 
 #endif /* COMMON_INC_H_ */

--- a/libraries/Adafruit_LittleFS/src/littlefs/lfs_util.h
+++ b/libraries/Adafruit_LittleFS/src/littlefs/lfs_util.h
@@ -24,8 +24,6 @@
 #include <stdbool.h>
 #include <string.h>
 
-#include "FreeRTOS.h"
-
 #ifndef LFS_NO_MALLOC
 #include <stdlib.h>
 #endif
@@ -56,21 +54,21 @@ extern "C"
 // Logging functions
 #ifndef LFS_NO_DEBUG
 #define LFS_DEBUG(fmt, ...) \
-    PRINTF("lfs debug:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+    printf("lfs debug:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else
 #define LFS_DEBUG(fmt, ...)
 #endif
 
 #ifndef LFS_NO_WARN
 #define LFS_WARN(fmt, ...) \
-    PRINTF("lfs warn:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+    printf("lfs warn:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else
 #define LFS_WARN(fmt, ...)
 #endif
 
 #ifndef LFS_NO_ERROR
 #define LFS_ERROR(fmt, ...) \
-    PRINTF("lfs error:%d: " fmt "\n", __LINE__, __VA_ARGS__)
+    printf("lfs error:%d: " fmt "\n", __LINE__, __VA_ARGS__)
 #else
 #define LFS_ERROR(fmt, ...)
 #endif


### PR DESCRIPTION
Follow up to #454 https://github.com/adafruit/Adafruit_nRF52_Arduino/pull/454/files#r395434902
cause compilation error with debug level 1.