### PR TITLE
Added Missing Pin Assignments for Xenon Board

### DIFF
--- a/variants/particle_xenon/variant.cpp
+++ b/variants/particle_xenon/variant.cpp
@@ -52,30 +52,42 @@ const uint32_t g_ADigitalPinMap[] =
   _PINNUM(0, 11),   // P0.11 (MODE)
   _PINNUM(0, 18),   // P0.18 (RESET)
 
+  // D22 .. D24
   // LEDS
   _PINNUM(0, 13),   // P0.13 (RGB_RED)
   _PINNUM(0, 14),   // P0.14 (RGB_GREEN)
   _PINNUM(0, 15),   // P0.15 (RGB_BLUE) 
 
+  // D25 .. D26
   // Antenna
   _PINNUM(0, 24),   // P0.24 (ANTENNA_SWITCH_1 - PCB ANTENNA)
   _PINNUM(0, 25),   // P0.25 (ANTENNA_SWITCH_2 - EXTERNAL u.FL)
 
+  // D27 .. D28
   // NFC
   _PINNUM(0, 9),    // P0.09 (u.FL FOR NFC ANTENNA)
   _PINNUM(0, 10),   // P0.10 (u.FL FOR NFC ANTENNA)
 
+  // D29 .. 36
   // Analog Pins A0 .. A7
   _PINNUM(0, 3),    // P0.03 (A0)
   _PINNUM(0, 4),    // P0.04 (A1)
-  _PINNUM(0, 28),   // P0.04 (A2)
-  _PINNUM(0, 29),   // P0.04 (A3)
-  _PINNUM(0, 30),   // P0.04 (A4)
-  _PINNUM(0, 31),   // P0.04 (A5)
-  _PINNUM(0, 5),   // P0.04 (BAT_DET/VBAT)
+  _PINNUM(0, 28),   // P0.28 (A2)
+  _PINNUM(0, 29),   // P0.29 (A3)
+  _PINNUM(0, 30),   // P0.30 (A4)
+  _PINNUM(0, 31),   // P0.31 (A5)
+  _PINNUM(0, 5),   // P0.05 (BAT_DET/VBAT)
   _PINNUM(0, 2),   // P0.02 (AREF)
+
+  // D37 .. D38
+  // Power status
+  _PINNUM(0, 12),  // P0.12 (PWR)
+  _PINNUM(1, 9),   // P1.09 (CHG)
 };
 
 void initVariant()
 {
+  // LED1
+  pinMode(PIN_LED1, OUTPUT);
+  ledOff(PIN_LED1);
 }

--- a/variants/particle_xenon/variant.h
+++ b/variants/particle_xenon/variant.h
@@ -39,8 +39,8 @@ extern "C"
 #endif // __cplusplus
 
 // Number of pins defined in PinDescription array
-#define PINS_COUNT           (34)
-#define NUM_DIGITAL_PINS     (20)
+#define PINS_COUNT           (39)
+#define NUM_DIGITAL_PINS     (39)
 #define NUM_ANALOG_INPUTS    (6) // A6 is used for battery, A7 is analog reference
 #define NUM_ANALOG_OUTPUTS   (0)
 
@@ -111,10 +111,10 @@ static const uint8_t LED_RGB_BLUE  = (24);
 // Buttons
 #define BUTTONS_NUMBER 2
 #define BUTTON_DFU                  (20)
-#define BUTTON_FRESET               (21) // A0
+#define BUTTON_FRESET               (19) // A0
 #define BUTTON_PULL    NRF_GPIO_PIN_PULLUP
 
-static const uint8_t BUTTON_MODE =  (20);
+static const uint8_t BUTTON_MODE =  BUTTON_DFU;
 
 // Antenna
 #define ANTENNA_SWITCH_1            (25)
@@ -150,6 +150,8 @@ static const uint8_t A7 = PIN_A7;
 // Other pins
 #define PIN_AREF           PIN_A7
 #define PIN_VBAT           PIN_A6
+#define PIN_PWR            (37)
+#define PIN_CHG            (38)
 
 static const uint8_t AREF = PIN_AREF;
 


### PR DESCRIPTION
Xenon board can tell when it is getting powered through the USB rather than a battery and when a battery is being charged. Added required pins inside variant files and the pins work as specified:

- When PIN_PWD is HIGH, Xenon is being powered through the USB
- When PIN_CHG is LOW, a battery attached to Xenon is being charged

Note: Prior to using these pins it is neccessary to specify pinMode(PIN_CHG, INPUT) and pinMode(PIN_PWR, INPUT) due to how they're being implemented in hardware. Using these two pins 3 states of power can be deduced:
- hasUsbPower = digitalRead(PIN_PWR);
- isCharging = (hasUsbPower && !digitalRead(PIN_CHG));
- onBatteryPower = !hasUsbPower;

BUTTON_FRESET pin number assignment was fixed as previously it was pointing to a wrong pin.

Added the missing LED1 initialisation, which now mimics the behaviour of the other nRF52 boards.