### PR TITLE
Fix off-by-one in shiftIn function

### DIFF
--- a/cores/nRF5/wiring_shift.c
+++ b/cores/nRF5/wiring_shift.c
@@ -30,7 +30,7 @@ uint32_t shiftIn( uint32_t ulDataPin, uint32_t ulClockPin, uint32_t ulBitOrder )
   uint8_t value = 0 ;
   uint8_t i ;
 
-  for ( i=0 ; i < 8 ; ++i )
+  for ( i=0 ; i < 8 ; i++ )
   {
     digitalWrite( ulClockPin, HIGH ) ;
 


### PR DESCRIPTION
This fixes the common `++i` vs `i++` bug in the `shiftIn` function of the Arduino core.

Took me a whole day to find... :cry: 