### PR TITLE
Making the nRF52840 Express BSP multiprotocol friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,5 +20,7 @@
 # Ignore local overrides of platform.txt and boards.txt,
 /boards.local.txt
 /platform.local.txt
+
+# Ignore S340 SoftDevice due to license restrictions
 bootloader/feather_nrf52840_express/feather_nrf52840_express_bootloader-0.3.0_s340_6.1.1.*
 cores/nRF5/nordic/softdevice/s340_nrf52_6.1.1_API/*

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,5 @@
 # Ignore local overrides of platform.txt and boards.txt,
 /boards.local.txt
 /platform.local.txt
-bootloader/feather_nrf52840_express/feather_nrf52840_express_bootloader-0.3.0_s340_6.1.1.hex
-bootloader/feather_nrf52840_express/feather_nrf52840_express_bootloader-0.3.0_s340_6.1.1.zip
+bootloader/feather_nrf52840_express/feather_nrf52840_express_bootloader-0.3.0_s340_6.1.1.*
 cores/nRF5/nordic/softdevice/s340_nrf52_6.1.1_API/*

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 # Ignore local overrides of platform.txt and boards.txt,
 /boards.local.txt
 /platform.local.txt
+bootloader/feather_nrf52840_express/feather_nrf52840_express_bootloader-0.3.0_s340_6.1.1.hex
+bootloader/feather_nrf52840_express/feather_nrf52840_express_bootloader-0.3.0_s340_6.1.1.zip
+cores/nRF5/nordic/softdevice/s340_nrf52_6.1.1_API/*

--- a/boards.txt
+++ b/boards.txt
@@ -116,6 +116,60 @@ feather52840.menu.debug.l3=Level 3 (Segger SystemView)
 feather52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 feather52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
+# ----------------------------------
+# Bluefruit Feather nRF52840 Express s340
+# ----------------------------------
+feather52840_s340.name=Adafruit Bluefruit Feather nRF52840 Express S340
+
+# VID/PID for bootloader with/without UF2, Arduino + Circuitpython App
+feather52840_s340.vid.0=0x239A
+feather52840_s340.pid.0=0x8029
+feather52840_s340.vid.1=0x239A
+feather52840_s340.pid.1=0x0029
+feather52840_s340.vid.2=0x239A
+feather52840_s340.pid.2=0x002A
+feather52840_s340.vid.3=0x239A
+feather52840_s340.pid.3=0x802A
+
+# Upload
+feather52840_s340.bootloader.tool=bootburn
+feather52840_s340.upload.tool=nrfutil
+feather52840_s340.upload.protocol=nrfutil
+feather52840_s340.upload.use_1200bps_touch=true
+feather52840_s340.upload.wait_for_upload_port=true
+feather52840_s340.upload.maximum_size=815104
+feather52840_s340.upload.maximum_data_size=237568
+#TODO: fix sizes above
+
+# Build
+feather52840_s340.build.mcu=cortex-m4
+feather52840_s340.build.f_cpu=64000000
+feather52840_s340.build.board=NRF52840_FEATHER
+feather52840_s340.build.core=nRF5
+feather52840_s340.build.variant=feather_nrf52840_express
+feather52840_s340.build.usb_manufacturer="Adafruit LLC"
+feather52840_s340.build.usb_product="Feather nRF52840 Express"
+feather52840_s340.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
+feather52840_s340.build.ldscript=nrf52840_s340_v6.ld
+feather52840_s340.build.vid=0x239A
+feather52840_s340.build.pid=0x8029
+
+# SofDevice Menu
+feather52840_s340.menu.softdevice.s340v6=0.3.0 SoftDevice s340 6.1.1
+feather52840_s340.menu.softdevice.s340v6.build.sd_name=s340
+feather52840_s340.menu.softdevice.s340v6.build.sd_version=6.1.1
+feather52840_s340.menu.softdevice.s340v6.build.sd_fwid=0x00B9
+
+# Debug Menu
+feather52840_s340.menu.debug.l0=Level 0 (Release)
+feather52840_s340.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
+feather52840_s340.menu.debug.l1=Level 1 (Error Message)
+feather52840_s340.menu.debug.l1.build.debug_flags=-DCFG_DEBUG=1
+feather52840_s340.menu.debug.l2=Level 2 (Full Debug)
+feather52840_s340.menu.debug.l2.build.debug_flags=-DCFG_DEBUG=2
+feather52840_s340.menu.debug.l3=Level 3 (Segger SystemView)
+feather52840_s340.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
+
 
 # ----------------------------------
 # Feather Bluefruit sense

--- a/cores/nRF5/linker/nrf52840_s340_v6.ld
+++ b/cores/nRF5/linker/nrf52840_s340_v6.ld
@@ -1,0 +1,39 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx)     : ORIGIN = 0x31000, LENGTH = 0xF4000 - 0x31000
+
+  /* SRAM required by S132 depend on
+   * - Attribute Table Size (Number of Services and Characteristics)
+   * - Vendor UUID count
+   * - Max ATT MTU
+   * - Concurrent connection peripheral + central + secure links
+   * - Event Len, HVN queue, Write CMD queue
+   */ 
+  /*RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000*/
+  RAM (rwx) :  ORIGIN = 0x20003400, LENGTH = 0x20040000 - 0x20003400
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .svc_data :
+  {
+    PROVIDE(__start_svc_data = .);
+    KEEP(*(.svc_data))
+    PROVIDE(__stop_svc_data = .);
+  } > RAM
+  
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+} INSERT AFTER .data;
+
+INCLUDE "nrf52_common.ld"

--- a/cores/nRF5/nordic/softdevice/s340_nrf52_6.1.1_API/readme.txt
+++ b/cores/nRF5/nordic/softdevice/s340_nrf52_6.1.1_API/readme.txt
@@ -1,0 +1,32 @@
+This directory needs to store the v6.1.1 version of the BLE+ANT combinded S340 softdevice headers 
+The way you can get that is described here: https://www.nordicsemi.com/Software-and-tools/Software/S340-ANT
+
+IMPORTANT:  You should put the S340 library headers under: s340_nrf52_6.1.1_API
+
+That is, your library tree should look like this:
+
+ s340_nrf52_6.1.1_API
+ └── include
+     ├── ant_error.h
+     ├── ant_interface.h
+     ├── ant_parameters.h
+     ├── ble.h
+     ├── ble_err.h
+     ├── ble_gap.h
+     ├── ble_gatt.h
+     ├── ble_gattc.h
+     ├── ble_gatts.h
+     ├── ble_hci.h
+     ├── ble_l2cap.h
+     ├── ble_ranges.h
+     ├── ble_types.h
+     ├── nrf52
+     │   └── nrf_mbr.h
+     ├── nrf_error.h
+     ├── nrf_error_sdm.h
+     ├── nrf_error_soc.h
+     ├── nrf_nvic.h
+     ├── nrf_sd_def.h
+     ├── nrf_sdm.h
+     ├── nrf_soc.h
+     └── nrf_svc.h

--- a/libraries/Bluefruit52Lib/src/bluefruit.h
+++ b/libraries/Bluefruit52Lib/src/bluefruit.h
@@ -179,6 +179,11 @@ class AdafruitBluefruit
     BLEConnection* Connection(uint16_t conn_hdl);
 
     /*------------------------------------------------------------------*/
+    /* ANT semaphore to signal when an SD event arrives if S340 Softdevice is used. 
+     *------------------------------------------------------------------*/
+    void setANTprotocolSemaphore(SemaphoreHandle_t* p_ant_event_semaphore) { _ant_event_sem= p_ant_event_semaphore;} 
+
+    /*------------------------------------------------------------------*/
     /* Callbacks
      *------------------------------------------------------------------*/
     void setRssiCallback(rssi_callback_t fp);
@@ -222,6 +227,8 @@ class AdafruitBluefruit
 
     SemaphoreHandle_t _ble_event_sem;
     SemaphoreHandle_t _soc_event_sem;
+    SemaphoreHandle_t* _ant_event_sem;
+
 
     TimerHandle_t _led_blink_th;
     bool _led_conn;

--- a/platform.txt
+++ b/platform.txt
@@ -140,7 +140,7 @@ tools.nrfutil.upload.pattern="{cmd}" {upload.verbose} dfu serial -pkg "{build.pa
 #***************************************************
 
 # Bootloader version
-tools.bootburn.bootloader.file={runtime.platform.path}/bootloader/{build.variant}/{build.variant}_bootloader-0.3.2_{build.sd_name}_{build.sd_version}
+tools.bootburn.bootloader.file={runtime.platform.path}/bootloader/{build.variant}/{build.variant}_bootloader-0.3.0_{build.sd_name}_{build.sd_version}
 
 tools.bootburn.bootloader.params.verbose=
 tools.bootburn.bootloader.params.quiet=

--- a/platform.txt
+++ b/platform.txt
@@ -140,7 +140,7 @@ tools.nrfutil.upload.pattern="{cmd}" {upload.verbose} dfu serial -pkg "{build.pa
 #***************************************************
 
 # Bootloader version
-tools.bootburn.bootloader.file={runtime.platform.path}/bootloader/{build.variant}/{build.variant}_bootloader-0.3.0_{build.sd_name}_{build.sd_version}
+tools.bootburn.bootloader.file={runtime.platform.path}/bootloader/{build.variant}/{build.variant}_bootloader-0.3.2_{build.sd_name}_{build.sd_version}
 
 tools.bootburn.bootloader.params.verbose=
 tools.bootburn.bootloader.params.quiet=


### PR DESCRIPTION
Hi, I would like to ask for some modifications to the nRF52 Arduino core for making it easier to use nRF52840 Express with BLE & ANT+ protocol stacks together. That necessitates 
- modificiations to the bootloader (which will come in a separate PR, since that is a different repo)
- modifications to board menu (I added a new board menu for the board with the S340 SoftDevice (SD) calling it "Bluefruit Feather nRF52840 Express s340")
- some modification to the class AdafruitBluefruit , since the ANT+ protocol stack needs its own FreeRTOS task and the S340 soft-device-enable() method has longer method-signature. 

For multiprotocol usage I had to make the class AdafruitBluefruit a little better behaving FreeRTOS citizen. The changes are as follows: 
- If the ANT_LICENSE_KEY symbol is defined then the code assumes S340 softdevice and it calls sd_softdevice_enable(...) with 3 args, otherwise it falls back to the S140 variant of 2 args.
- I added a private pointer to an optional ANT+ task handler semaphore, which is initialized to NULL and a corresponding setter method to supply an external semaphore reference
-  SD_EVT_IRQHandler() now checks that semaphore pointer and if it is set then it throws a "give" to the new semaphore, as well, beyond the legacy BLE and the SoC semaphores.

With these changes I was able to run the BLE & ANT stacks concurrently on my nRF52840 Express updated with S340 SD. I am currently using some ANT+ sensor reading together with Adafruit's BLEUART example, which latter needed no changes at all. 

As such, I believe all these changes are backward compatible for boards with S140. The changes are transparent for legacy Bluefruit52-dependent code, i.e., these should be harmless for existing users' sketches. The only visible difference for the users would be the appearance of a new board-type in the Arduino/PlatformIo board-menu. 

You can read further details at my Wiki below (Note, those articles were written a few months ago, so they reflect an earlier SW version of your code): 
- [S340 SoftDevice & Adafruit nRF52840 Feather Express](http://orrmany.hu/wiki/doku.php?id=arduino:s340_softdevice_adafruit_nrf52840_feather_express)
- [Arduino IDE integration for the nRF52840 Feather Express with S340](http://orrmany.hu/wiki/doku.php?id=s340:arduino_ide_integration_for_the_nrf52840_feather_express_with_s340)
- [PlatformIO IDE integration for the nRF52840 Feather Express with S340](http://orrmany.hu/wiki/doku.php?id=s340:platformio_ide_integration_for_the_nrf52840_feather_express_with_s340)

Credit shall also go to @rtgree01 ([Ryan Green](https://github.com/rtgree01/Adafruit_nRF52_Arduino)) who made most of the early hacks of these and he kindly shared his results with me and @cujomalainey [Curtis Malainey](https://github.com/cujomalainey). 