### PR TITLE
Add a rename(oldfilename, newfilename) method to LittleFS class

### DIFF
--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
@@ -195,6 +195,18 @@ bool Adafruit_LittleFS::remove (char const *filepath)
   return LFS_ERR_OK == err;
 }
 
+// Rename a file
+bool Adafruit_LittleFS::rename (char const *oldfilepath, char const *newfilepath)
+{
+  _lockFS();
+
+  int err = lfs_rename(&_lfs, oldfilepath, newfilepath);
+  PRINT_LFS_ERR(err);
+
+  _unlockFS();
+  return LFS_ERR_OK == err;
+}
+
 // Remove a folder
 bool Adafruit_LittleFS::rmdir (char const *filepath)
 {

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
@@ -58,6 +58,9 @@ class Adafruit_LittleFS
     // Delete the file.
     bool remove (char const *filepath);
 
+    // Rename the file.
+    bool rename (char const *oldfilepath, char const *newfilepath);
+
     // Delete a folder (must be empty)
     bool rmdir (char const *filepath);
 


### PR DESCRIPTION
Just adding a missing file rename method in the LittleFS class.  Original code copied from ::remove and just changed to call lfs_rename.  Tested on a nRF52840-DK.