### PR TITLE
Add truncate method to Adafruit_LittleFS_File.

### DIFF
--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -272,6 +272,32 @@ uint32_t File::size (void)
   return ret;
 }
 
+bool File::truncate (uint32_t pos)
+{
+  uint32_t ret=0;
+  _fs->_lockFS();
+  if (!this->_is_dir)
+  {
+    ret = lfs_file_truncate(_fs->_getFS(), _file, pos);
+  }
+  _fs->_unlockFS();
+  return ( ret == 0 );
+}
+
+bool File::truncate (void)
+{
+  uint32_t ret=0;
+  uint32_t pos;
+  _fs->_lockFS();
+  if (!this->_is_dir)
+  {
+    pos = lfs_file_tell(_fs->_getFS(), _file);
+    ret = lfs_file_truncate(_fs->_getFS(), _file, pos);
+  }
+  _fs->_unlockFS();
+  return ( ret == 0 );
+}
+
 void File::flush (void)
 {
   _fs->_lockFS();

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -274,7 +274,7 @@ uint32_t File::size (void)
 
 bool File::truncate (uint32_t pos)
 {
-  uint32_t ret=0;
+  uint32_t ret=1;
   _fs->_lockFS();
   if (!this->_is_dir)
   {
@@ -286,7 +286,7 @@ bool File::truncate (uint32_t pos)
 
 bool File::truncate (void)
 {
-  uint32_t ret=0;
+  uint32_t ret=1;
   uint32_t pos;
   _fs->_lockFS();
   if (!this->_is_dir)

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -274,7 +274,7 @@ uint32_t File::size (void)
 
 bool File::truncate (uint32_t pos)
 {
-  uint32_t ret=1;
+  int32_t ret=LFS_ERR_ISDIR;
   _fs->_lockFS();
   if (!this->_is_dir)
   {
@@ -286,7 +286,7 @@ bool File::truncate (uint32_t pos)
 
 bool File::truncate (void)
 {
-  uint32_t ret=1;
+  int32_t ret=LFS_ERR_ISDIR;
   uint32_t pos;
   _fs->_lockFS();
   if (!this->_is_dir)

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.h
@@ -70,6 +70,9 @@ class File : public Stream
     uint32_t position (void);
     uint32_t size (void);
 
+    bool truncate (uint32_t pos);
+    bool truncate (void);
+
     void close (void);
 
     operator bool (void);


### PR DESCRIPTION
Adds a truncate method with semantics like Unix ftruncate and a version with no parameter that truncates to the current file
position.