### PR TITLE
Add missing LED pin defines for PCA10056

### DIFF
--- a/variants/pca10056/variant.h
+++ b/variants/pca10056/variant.h
@@ -45,6 +45,8 @@ extern "C"
 // LEDs
 #define PIN_LED1             (13)
 #define PIN_LED2             (14)
+#define PIN_LED3             (15)
+#define PIN_LED4             (16)
 
 #define LED_BUILTIN          PIN_LED1
 #define LED_CONN             PIN_LED2


### PR DESCRIPTION
Add the 2 missing LED defines. Tested on my board and LEDs 3 and 4 toggle as expected with this change.