### PR TITLE
label new/delete as weakly bound.  So that apps can redefine as needed

### DIFF
--- a/cores/nRF5/new.cpp
+++ b/cores/nRF5/new.cpp
@@ -23,27 +23,27 @@
 #include <sys/stat.h>
 #include <malloc.h>
 
-void *operator new(size_t size) {
+void __attribute__((weak)) *operator new(size_t size) {
   return rtos_malloc(size);
 }
 
-void *operator new[](size_t size) {
+void __attribute__((weak)) *operator new[](size_t size) {
   return rtos_malloc(size);
 }
 
-void operator delete(void * ptr) {
+void __attribute__((weak)) operator delete(void * ptr) {
   rtos_free(ptr);
 }
 
-void operator delete[](void * ptr) {
+void __attribute__((weak)) operator delete[](void * ptr) {
   rtos_free(ptr);
 }
 
-void operator delete(void * ptr, unsigned int) {
+void __attribute__((weak)) operator delete(void * ptr, unsigned int) {
   rtos_free(ptr);
 }
 
-void operator delete[](void * ptr, unsigned int) {
+void __attribute__((weak)) operator delete[](void * ptr, unsigned int) {
   rtos_free(ptr);
 }
 


### PR DESCRIPTION
Sometimes app developers need to redefine new/delete for debugging or other purposes.  This changes the definitions to have the weak attribute, so that will be allowed by the linker rather than throwing an error. 