### PR TITLE
Fix  BLEDiscovery::discoverCharacteristic when the central device returns more than 4 Characteristics in a discovery request

### DIFF
--- a/libraries/Bluefruit52Lib/src/BLEDiscovery.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEDiscovery.cpp
@@ -109,7 +109,8 @@ uint8_t BLEDiscovery::discoverCharacteristic(uint16_t conn_handle, BLEClientChar
   // We could found more characteristic than we looking for. Buffer must be large enough
   enum { MAX_DISC_CHARS = 4 };
 
-  uint16_t bufsize = sizeof(ble_gattc_evt_char_disc_rsp_t) + (MAX_DISC_CHARS-1)*sizeof(ble_gattc_char_t);
+  // -1 because the first ble_gattc_char_t is built in to ble_gattc_evt_char_disc_rsp_t
+  uint16_t bufsize = sizeof(ble_gattc_evt_char_disc_rsp_t) + (MAX_DISC_CHARS-1)*sizeof(ble_gattc_char_t); 
   ble_gattc_evt_char_disc_rsp_t* disc_chr = (ble_gattc_evt_char_disc_rsp_t*) rtos_malloc( bufsize );
 
   uint8_t found = 0;
@@ -128,6 +129,9 @@ uint8_t BLEDiscovery::discoverCharacteristic(uint16_t conn_handle, BLEClientChar
 
     // timeout or has no data (due to GATT Error)
     if ( bytecount <= 0 ) break;
+
+    if ( disc_chr->count > MAX_DISC_CHARS ) // if we truncated the response, adjust the count to match
+      disc_chr->count = MAX_DISC_CHARS;
 
     // Look for matched uuid in the discovered list
     for(uint8_t d=0 ; d<disc_chr->count; d++)

--- a/libraries/Bluefruit52Lib/src/BLEDiscovery.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEDiscovery.cpp
@@ -130,8 +130,8 @@ uint8_t BLEDiscovery::discoverCharacteristic(uint16_t conn_handle, BLEClientChar
     // timeout or has no data (due to GATT Error)
     if ( bytecount <= 0 ) break;
 
-    if ( disc_chr->count > MAX_DISC_CHARS ) // if we truncated the response, adjust the count to match
-      disc_chr->count = MAX_DISC_CHARS;
+    // if we truncated the response, adjust the count to match
+    if ( disc_chr->count > MAX_DISC_CHARS ) disc_chr->count = MAX_DISC_CHARS;
 
     // Look for matched uuid in the discovered list
     for(uint8_t d=0 ; d<disc_chr->count; d++)

--- a/libraries/Bluefruit52Lib/src/BLEDiscovery.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEDiscovery.cpp
@@ -107,7 +107,7 @@ bool BLEDiscovery::_discoverService(uint16_t conn_handle, BLEClientService& svc,
 uint8_t BLEDiscovery::discoverCharacteristic(uint16_t conn_handle, BLEClientCharacteristic* chr[], uint8_t count)
 {
   // We could found more characteristic than we looking for. Buffer must be large enough
-  enum { MAX_DISC_CHARS = 4 };
+  enum { MAX_DISC_CHARS = 8 };
 
   // -1 because the first ble_gattc_char_t is built in to ble_gattc_evt_char_disc_rsp_t
   uint16_t bufsize = sizeof(ble_gattc_evt_char_disc_rsp_t) + (MAX_DISC_CHARS-1)*sizeof(ble_gattc_char_t); 


### PR DESCRIPTION
Recover gracefully when a BLE peripheral returns more than 4 characteristics in a reply to a discovery request by clamping the reply's characteristic count to match what's actually in the truncated reply.

Should fix issue #514.