### PR TITLE
Added I2C pin configuration

### DIFF
--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -39,7 +39,7 @@ class TwoWire : public Stream
     void begin(uint8_t);
     void end();
     void setClock(uint32_t);
-	void setPins(uint8_t pinSDA, uint8_t pinSCL);
+    void setPins(uint8_t pinSDA, uint8_t pinSCL);
 
     void beginTransmission(uint8_t);
     uint8_t endTransmission(bool stopBit);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -39,7 +39,7 @@ class TwoWire : public Stream
     void begin(uint8_t);
     void end();
     void setClock(uint32_t);
-	void setPins(uint8_t pin_SDA, uint8_t pin_SCL);
+	void setPins(uint8_t pinSDA, uint8_t pinSCL);
 
     void beginTransmission(uint8_t);
     uint8_t endTransmission(bool stopBit);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -39,6 +39,7 @@ class TwoWire : public Stream
     void begin(uint8_t);
     void end();
     void setClock(uint32_t);
+	void setPins(uint8_t pin_SDA, uint8_t pin_SCL);
 
     void beginTransmission(uint8_t);
     uint8_t endTransmission(bool stopBit);

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -127,10 +127,10 @@ void TwoWire::setClock(uint32_t baudrate) {
   }
 }
 
-void TwoWire::setPins(uint8_t pin_SDA, uint8_t pin_SCL)
+void TwoWire::setPins(uint8_t pinSDA, uint8_t pinSCL)
 {
-	this->_uc_pinSDA = g_ADigitalPinMap[pin_SDA];
-	this->_uc_pinSCL = g_ADigitalPinMap[pin_SCL];
+    this->_uc_pinSDA = g_ADigitalPinMap[pinSDA];
+    this->_uc_pinSCL = g_ADigitalPinMap[pinSCL];
 }
 
 void TwoWire::end() {

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -127,6 +127,12 @@ void TwoWire::setClock(uint32_t baudrate) {
   }
 }
 
+void TwoWire::setPins(uint8_t pin_SDA, uint8_t pin_SCL)
+{
+	this->_uc_pinSDA = g_ADigitalPinMap[pin_SDA];
+	this->_uc_pinSCL = g_ADigitalPinMap[pin_SCL];
+}
+
 void TwoWire::end() {
   if (master)
   {


### PR DESCRIPTION
To configure the I2C pins call Wire.setPins(SDA_Pin, SCL_pin) prior to Wire.begin()