### PR TITLE
Init all onboard LEDs for pca10056

### DIFF
--- a/variants/pca10056/variant.cpp
+++ b/variants/pca10056/variant.cpp
@@ -39,11 +39,17 @@ const uint32_t g_ADigitalPinMap[] =
 
 void initVariant()
 {
-  // LED1 & LED2
+  // init all 4 onboard LEDs
   pinMode(PIN_LED1, OUTPUT);
   ledOff(PIN_LED1);
 
   pinMode(PIN_LED2, OUTPUT);
-  ledOff(PIN_LED2);;
+  ledOff(PIN_LED2);
+
+  pinMode(PIN_LED3, OUTPUT);
+  ledOff(PIN_LED3);
+
+  pinMode(PIN_LED4, OUTPUT);
+  ledOff(PIN_LED4);
 }
 


### PR DESCRIPTION
Need to init the 2 missing onboard LEDs for pca10056.

Sorry! Would have added this in my previous PR but just noticed it!