### PR TITLE
fix power usbready not handled if bluefruit begin() is called fast enough

### DIFF
--- a/cores/nRF5/TinyUSB/Adafruit_TinyUSB_nRF.cpp
+++ b/cores/nRF5/TinyUSB/Adafruit_TinyUSB_nRF.cpp
@@ -63,6 +63,14 @@ extern "C" void USBD_IRQHandler(void)
 // Init usb hardware when starting up. Softdevice is not enabled yet
 static void usb_hardware_init(void)
 {
+  // Priorities 0, 1, 4 (nRF52) are reserved for SoftDevice
+  // 2 is highest for application
+  NVIC_SetPriority(USBD_IRQn, 2);
+
+  // USB power may already be ready at this time -> no event generated
+  // We need to invoke the handler based on the status initially
+  uint32_t usb_reg = NRF_POWER->USBREGSTATUS;
+
   // Power module init
   const nrfx_power_config_t pwr_cfg = { 0 };
   nrfx_power_init(&pwr_cfg);
@@ -73,16 +81,7 @@ static void usb_hardware_init(void)
 
   nrfx_power_usbevt_enable();
 
-  // Priorities 0, 1, 4 (nRF52) are reserved for SoftDevice
-  // 2 is highest for application
-  NVIC_SetPriority(USBD_IRQn, 2);
-
-  // USB power may already be ready at this time -> no event generated
-  // We need to invoke the handler based on the status initially
-  uint32_t usb_reg = NRF_POWER->USBREGSTATUS;
-
   if ( usb_reg & POWER_USBREGSTATUS_VBUSDETECT_Msk ) tusb_hal_nrf_power_event(NRFX_POWER_USB_EVT_DETECTED);
-  if ( usb_reg & POWER_USBREGSTATUS_OUTPUTRDY_Msk  ) tusb_hal_nrf_power_event(NRFX_POWER_USB_EVT_READY);
 }
 
 // USB Device Driver task
@@ -91,7 +90,7 @@ static void usb_device_task(void* param)
 {
   (void) param;
 
-  USBDevice.addInterface( (Adafruit_USBD_Interface&) Serial);
+  USBDevice.addInterface((Adafruit_USBD_Interface&) Serial);
   USBDevice.setID(USB_VID, USB_PID);
   USBDevice.begin();
 
@@ -111,7 +110,7 @@ static void usb_device_task(void* param)
 void Adafruit_TinyUSB_Core_init(void)
 {
   // Create a task for tinyusb device stack
-  xTaskCreate( usb_device_task, "usbd", USBD_STACK_SZ, NULL, TASK_PRIO_HIGH, NULL);
+  xTaskCreate(usb_device_task, "usbd", USBD_STACK_SZ, NULL, TASK_PRIO_HIGH, NULL);
 }
 
 void Adafruit_TinyUSB_Core_touch1200(void)

--- a/cores/nRF5/TinyUSB/tusb_config.h
+++ b/cores/nRF5/TinyUSB/tusb_config.h
@@ -44,6 +44,10 @@
 #define CFG_TUSB_MEM_SECTION
 #define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
 
+#ifndef CFG_TUSB_DEBUG
+#define CFG_TUSB_DEBUG              0
+#endif
+
 //--------------------------------------------------------------------
 // DEVICE CONFIGURATION
 //--------------------------------------------------------------------

--- a/cores/nRF5/freertos/config/FreeRTOSConfig.h
+++ b/cores/nRF5/freertos/config/FreeRTOSConfig.h
@@ -139,8 +139,7 @@
     #endif
 #endif /* !assembler */
 
-/* The lowest interrupt priority that can be used in a call to a "set priority"
-function. */
+/* The lowest interrupt priority that can be used in a call to a "set priority" function. */
 #define configLIBRARY_LOWEST_INTERRUPT_PRIORITY                   ((1<<configPRIO_BITS) - 1)
 
 /* The highest interrupt priority that can be used by any interrupt service

--- a/cores/nRF5/main.cpp
+++ b/cores/nRF5/main.cpp
@@ -26,6 +26,7 @@ void Bluefruit_printInfo() {}
 
 // From the UI, setting debug level to 3 will enable SysView
 #if CFG_SYSVIEW
+#include "SEGGER_RTT.h"
 #include "SEGGER_SYSVIEW.h"
 #endif
 
@@ -107,10 +108,16 @@ int _write (int fd, const void *buf, size_t count)
 {
   (void) fd;
 
+#if 0 // CFG_SYSVIEW
+  SEGGER_RTT_Write(0, (char*) buf, (int) count);
+  return count;
+#else
   if ( Serial )
   {
     return Serial.write( (const uint8_t *) buf, count);
   }
+#endif
+
   return 0;
 }
 

--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -76,6 +76,17 @@ void usb_softdevice_post_enable(void)
   sd_power_usbdetected_enable(true);
   sd_power_usbpwrrdy_enable(true);
   sd_power_usbremoved_enable(true);
+
+  uint32_t usb_reg;
+  sd_power_usbregstatus_get(&usb_reg);
+
+  // Note: Detect event is possibly handled by usb_hardware_init() however depending on how fast
+  // Bluefruit.begin() is called, Ready event may or may not be handled before we disable the nrfx_power.
+  //    USBPULLUP not enabled -> Ready event not yet handled
+  if ( (usb_reg & POWER_USBREGSTATUS_OUTPUTRDY_Msk) && (NRF_USBD->USBPULLUP == 0) )
+  {
+    tusb_hal_nrf_power_event(NRFX_POWER_USB_EVT_READY);
+  }
 }
 
 #endif
@@ -163,7 +174,7 @@ AdafruitBluefruit::AdafruitBluefruit(void)
   _ble_event_sem = NULL;
   _soc_event_sem = NULL;
 #ifdef ANT_LICENSE_KEY
-  _mprot_event_sem = NULL; //additiona semaphore for multiprotocol 
+  _mprot_event_sem = NULL;
 #endif
 
   _led_blink_th  = NULL;
@@ -294,34 +305,31 @@ bool AdafruitBluefruit::begin(uint8_t prph_count, uint8_t central_count)
 #if defined( USE_LFXO )
   nrf_clock_lf_cfg_t clock_cfg =
   {
-      // LFXO
-      .source        = NRF_CLOCK_LF_SRC_XTAL,
-      .rc_ctiv       = 0,
-      .rc_temp_ctiv  = 0,
-      .accuracy      = NRF_CLOCK_LF_ACCURACY_20_PPM
+    // LFXO
+    .source        = NRF_CLOCK_LF_SRC_XTAL,
+    .rc_ctiv       = 0,
+    .rc_temp_ctiv  = 0,
+    .accuracy      = NRF_CLOCK_LF_ACCURACY_20_PPM
   };
 #elif defined( USE_LFRC )
   nrf_clock_lf_cfg_t clock_cfg = 
   {
-      // LXRC
-      .source        = NRF_CLOCK_LF_SRC_RC,
-      .rc_ctiv       = 16,
-      .rc_temp_ctiv  = 2,
-      .accuracy      = NRF_CLOCK_LF_ACCURACY_250_PPM
+    // LXRC
+    .source        = NRF_CLOCK_LF_SRC_RC,
+    .rc_ctiv       = 16,
+    .rc_temp_ctiv  = 2,
+    .accuracy      = NRF_CLOCK_LF_ACCURACY_250_PPM
   };
 #else
   #error Clock Source is not configured, define USE_LFXO or USE_LFRC according to your board in variant.h
 #endif
 
-  /*------------------------------------------------------------------
-  ** BLE only Softdevices have 2-args sd_softdevice_enable()
-  ** BLE & ANT+ Softdevices have 3-args sd_softdevice_enable()
-  */
-  #ifdef ANT_LICENSE_KEY
+  // Enable SoftDevice
+#ifdef ANT_LICENSE_KEY
   VERIFY_STATUS( sd_softdevice_enable(&clock_cfg, nrf_error_cb, ANT_LICENSE_KEY), false );
-#else //#ifdef ANT_LICENSE_KEY
+#else
   VERIFY_STATUS( sd_softdevice_enable(&clock_cfg, nrf_error_cb), false );
-#endif //#ifdef ANT_LICENSE_KEY
+#endif
 
 #ifdef USE_TINYUSB
   usb_softdevice_post_enable();
@@ -463,13 +471,6 @@ bool AdafruitBluefruit::begin(uint8_t prph_count, uint8_t central_count)
   // Default device name
   ble_gap_conn_sec_mode_t sec_mode = BLE_SECMODE_OPEN;
   VERIFY_STATUS(sd_ble_gap_device_name_set(&sec_mode, (uint8_t const *) CFG_DEFAULT_NAME, strlen(CFG_DEFAULT_NAME)), false);
-
-  //------------- USB -------------//
-#ifdef USE_TINYUSB
-  sd_power_usbdetected_enable(true);
-  sd_power_usbpwrrdy_enable(true);
-  sd_power_usbremoved_enable(true);
-#endif
 
   // Init Central role
   if (_central_count)  Central.begin();
@@ -684,12 +685,20 @@ bool AdafruitBluefruit::setPIN(const char* pin)
  *------------------------------------------------------------------*/
 void SD_EVT_IRQHandler(void)
 {
-  // Notify both BLE & SOC Task
+#if CFG_SYSVIEW
+  SEGGER_SYSVIEW_RecordEnterISR();
+#endif
+
+  // Notify both BLE & SOC & MultiProtocol (if any) Task
   xSemaphoreGiveFromISR(Bluefruit._soc_event_sem, NULL);
   xSemaphoreGiveFromISR(Bluefruit._ble_event_sem, NULL);
+
 #ifdef ANT_LICENSE_KEY
-  // Notify parallel multiprotocol Task, if any
   if (Bluefruit._mprot_event_sem)  xSemaphoreGiveFromISR(Bluefruit._mprot_event_sem, NULL);
+#endif
+
+#if CFG_SYSVIEW
+  SEGGER_SYSVIEW_RecordExitISR();
 #endif
 }
 


### PR DESCRIPTION
- fix POWER USB Ready may not  be handled when Bluefruit.begin() is invoked fast enough.
- fix #544 
- need https://github.com/hathach/tinyusb/pull/478 to be merged first then bump up the tinyusb core.
- Also clean up stuffs as well.

