### PR TITLE
a few delay before enter dfu by touch1200

### DIFF
--- a/cores/nRF5/TinyUSB/Adafruit_TinyUSB_nRF.cpp
+++ b/cores/nRF5/TinyUSB/Adafruit_TinyUSB_nRF.cpp
@@ -116,6 +116,7 @@ void Adafruit_TinyUSB_Core_init(void)
 
 void Adafruit_TinyUSB_Core_touch1200(void)
 {
+  delay(5); // a few millisecond for USB control status completion
   enterSerialDfu();
 }
 


### PR DESCRIPTION
latest freeRTOS change make usb much faster --> missing control status with touch 1200