### PR TITLE
micro() use DWT cyclecount if enabled else use rtos tick

### DIFF
--- a/cores/nRF5/delay.c
+++ b/cores/nRF5/delay.c
@@ -30,11 +30,6 @@ uint32_t millis( void )
   return tick2ms(xTaskGetTickCount());
 }
 
-uint32_t micros( void )
-{
-  return tick2us(xTaskGetTickCount());
-}
-
 void delay( uint32_t ms )
 {
   uint32_t ticks = ms2tick(ms);

--- a/cores/nRF5/freertos/portable/CMSIS/nrf52/port_cmsis_systick.c
+++ b/cores/nRF5/freertos/portable/CMSIS/nrf52/port_cmsis_systick.c
@@ -243,7 +243,7 @@ void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
                 // If dwt cycle count is enable, adjust it as welll
                 if ( (CoreDebug->DEMCR & CoreDebug_DEMCR_TRCENA_Msk) && (DWT->CTRL & DWT_CTRL_CYCCNTENA_Msk) )
                 {
-                  DWT->CYCCNT += ((diff * 1000000) / configTICK_RATE_HZ) * 64;
+                  DWT->CYCCNT += (((diff-1) * 1000000) / configTICK_RATE_HZ) * 64;
                 }
               
                 switch_req = xTaskIncrementTick();

--- a/cores/nRF5/freertos/portable/CMSIS/nrf52/port_cmsis_systick.c
+++ b/cores/nRF5/freertos/portable/CMSIS/nrf52/port_cmsis_systick.c
@@ -230,6 +230,12 @@ void vPortSuppressTicksAndSleep( TickType_t xExpectedIdleTime )
             if (diff > 0)
             {
                 vTaskStepTick(diff);
+
+                // If dwt cycle count is enable, adjust it as welll
+                if ( (CoreDebug->DEMCR & CoreDebug_DEMCR_TRCENA_Msk) && (DWT->CTRL & DWT_CTRL_CYCCNTENA_Msk) )
+                {
+                  DWT->CYCCNT += ((diff * 1000000) / configTICK_RATE_HZ) * 64;
+                }
             }
         }
     }


### PR DESCRIPTION
DWT must be previously enabled by user sketch with dwt_enable(). This should fix #451 