### PR TITLE
Add resumeLoop functionality

### DIFF
--- a/cores/nRF5/Arduino.h
+++ b/cores/nRF5/Arduino.h
@@ -37,7 +37,6 @@ void loop( void ) ;
 
 void suspendLoop(void);
 void resumeLoop(void);
-void resumeLoopFromISR(void);
 
 #include "WVariant.h"
 

--- a/cores/nRF5/Arduino.h
+++ b/cores/nRF5/Arduino.h
@@ -36,6 +36,8 @@ void setup( void ) ;
 void loop( void ) ;
 
 void suspendLoop(void);
+void resumeLoop(void);
+void resumeLoopFromISR(void);
 
 #include "WVariant.h"
 

--- a/cores/nRF5/main.cpp
+++ b/cores/nRF5/main.cpp
@@ -102,11 +102,14 @@ void suspendLoop(void)
 
 void resumeLoop(void)
 {
-  vTaskResume(_loopHandle);
-}
-
-void resumeLoopFromISR(void) {
-  xTaskResumeFromISR(_loopHandle);
+  if ( isInISR() ) 
+  {
+    xTaskResumeFromISR(_loopHandle);
+  } 
+  else
+  {
+    vTaskResume(_loopHandle);
+  }
 }
 
 extern "C"

--- a/cores/nRF5/main.cpp
+++ b/cores/nRF5/main.cpp
@@ -100,6 +100,15 @@ void suspendLoop(void)
   vTaskSuspend(_loopHandle);
 }
 
+void resumeLoop(void)
+{
+  vTaskResume(_loopHandle);
+}
+
+void resumeLoopFromISR(void) {
+  xTaskResumeFromISR(_loopHandle);
+}
+
 extern "C"
 {
 


### PR DESCRIPTION
Without `resumeLoop`/`resumeLoopFromISR` functions, suspendLoop is the same as terminateLoop. This enables an interrupt to trigger looping (using `resumeLoopFromISR`), which can then operate for some time, then suspend itself.

Example use: Use an interrupt to detect when a switch in a key matrix is pressed. Debouncing with only interrupts is nearly impossible. This allows the interrupt to trigger a normal "keymatrix scan & debounce" loop, which runs normally until debouncing time is over, then the loop can be suspended (thereby saving tremendous amounts of power).