### PR TITLE
Make definition of SERIAL_BUFFER_SIZE check if it is already defined (allows easier UART buffer size adjustment)

### DIFF
--- a/cores/nRF5/RingBuffer.h
+++ b/cores/nRF5/RingBuffer.h
@@ -25,7 +25,9 @@
 // using a ring buffer (I think), in which head is the index of the location
 // to which to write the next incoming character and tail is the index of the
 // location from which to read.
+#ifndef SERIAL_BUFFER_SIZE
 #define SERIAL_BUFFER_SIZE 64
+#endif
 
 class RingBuffer
 {


### PR DESCRIPTION
Currently, SERIAL_BUFFER_SIZE in cores/nRF5/RingBuffer.h is defined to have a specific value (64 in this case) regardless of whether it is already defined or not. This means that there is no way to change the size of the UART buffers without editing this file manually by each person who wants a different value. With the proposed change, the definition can be passed to the compiler from the command line and the header will honor it.

The equivalent header for the SAMD core (https://github.com/adafruit/ArduinoCore-samd/blob/bdf5ac811733a9fdaf618fc61d8f5dcb8303ca00/cores/arduino/RingBuffer.h#L31-L33) already allows this, so I don't think this is likely to cause any major problems.