### PR TITLE
fix ci build due to RotaryEncoder include

### DIFF
--- a/libraries/RotaryEncoder/library.properties
+++ b/libraries/RotaryEncoder/library.properties
@@ -1,5 +1,5 @@
 name=Rotary Encoder
-version=0.7.5
+version=0.8.0
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=Arduino library for nRF52-based Adafruit Bluefruit LE modules
@@ -7,4 +7,4 @@ paragraph=Arduino library for nRF52-based Adafruit Bluefruit LE modules
 category=Communication
 url=https://github.com/adafruit/Adafruit_nRF52_Arduino
 architectures=*
-includes=HardwareEncoder.h
+includes=RotaryEncoder.h


### PR DESCRIPTION
arduino-cli does a better job to catch library includes. This fixed current ci build