### PR TITLE
Make definitions for TinyUSB serial TX/RX buffer sizes check if they are already defined (allows easier serial buffer size adjustment)

### DIFF
--- a/cores/nRF5/TinyUSB/tusb_config.h
+++ b/cores/nRF5/TinyUSB/tusb_config.h
@@ -76,8 +76,12 @@
 #define CFG_TUD_MIDI_TX_BUFSIZE     128
 
 // Vendor FIFO size of TX and RX
+#ifndef CFG_TUD_VENDOR_RX_BUFSIZE
 #define CFG_TUD_VENDOR_RX_BUFSIZE   64
+#endif
+#ifndef CFG_TUD_VENDOR_TX_BUFSIZE
 #define CFG_TUD_VENDOR_TX_BUFSIZE   64
+#endif
 
 #ifdef __cplusplus
  }


### PR DESCRIPTION
Same ideas as in commit f3a70865d42e7a9a1afdc81f25d2a2939a99f57b (PR #575 ), but for the equivalent definitions for the RX and TX buffers for the USB serial in cores/nRF5/TinyUSB/tusb_config.h.

This lets one use pass the preprocessor definitions CFG_TUD_VENDOR_RX_BUFSIZE and CFG_TUD_VENDOR_TX_BUFSIZE and not have the header override the desired values.

