### PR TITLE
replace add-path with GITHUB_PATH env variable

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -36,7 +36,7 @@ jobs:
         mkdir $HOME/Arduino
         mkdir $HOME/Arduino/libraries
         curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | sh
-        echo "::add-path::$GITHUB_WORKSPACE/bin"
+        echo $GITHUB_WORKSPACE/bin >> $GITHUB_PATH
         
     - name: Install BSP and Libraries
       env:


### PR DESCRIPTION
replacing the add-path from github actions script so that CI keeps working...

message from github actions:
The `add-path` command is deprecated and will be disabled on November 16th. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/