### PR TITLE
Fixes MIDI read loop blocking other tasks in BLEMidi example

### DIFF
--- a/libraries/Bluefruit52Lib/examples/Peripheral/blemidi/blemidi.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/blemidi/blemidi.ino
@@ -174,5 +174,8 @@ void midiRead()
 
   // read any new MIDI messages
   MIDI.read();
+
+  // Allow the Scheduler to run other tasks
+  yield();
 }
 


### PR DESCRIPTION
Fixes #392

As described in that issue, the Arduino Scheduler seems to require that loops `delay()` or `yield()` periodically, otherwise other tasks may be blocked. Constructive criticism is welcome.