### PR TITLE
Adds MIDI Library v5 support

### DIFF
--- a/libraries/Bluefruit52Lib/src/services/BLEMidi.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEMidi.cpp
@@ -160,6 +160,15 @@ err_t BLEMidi::begin(void)
 
   return ERROR_NONE;
 }
+  
+bool BLEMidi::beginTransmission(MIDI_NAMESPACE::MidiType type)
+{
+  return true;
+};
+
+void BLEMidi::endTransmission()
+{
+}
 
 /*------------------------------------------------------------------*/
 /* Callbacks

--- a/libraries/Bluefruit52Lib/src/services/BLEMidi.h
+++ b/libraries/Bluefruit52Lib/src/services/BLEMidi.h
@@ -35,6 +35,8 @@
 #ifndef BLEMIDI_H_
 #define BLEMIDI_H_
 
+#include <MIDI.h>
+
 #include "bluefruit_common.h"
 #include "utility/adafruit_fifo.h"
 
@@ -73,6 +75,9 @@ class BLEMidi: public BLEService, public Stream
 
     void setWriteCallback(midi_write_cb_t fp);
     void autoMIDIread(void* midi_obj);
+
+    bool beginTransmission(MIDI_NAMESPACE::MidiType type);
+    void endTransmission();
 
     // Stream API for MIDI Interface
     virtual int    read       ( void );


### PR DESCRIPTION
Fixes #528 

Warning: I am well outside my wheelhouse here ⚠️ 

I do not know  `beginTransmission()` and `endTransmission()` methods are for. I see that the MIDI Library's serialMIDI implementation ignores them (https://github.com/FortySevenEffects/arduino_midi_library/blob/d9149d19df867abbf78cfcd37ef9d0e14dedca7f/src/serialMIDI.h#L66), so I tried that here, and it worked! (As far as I can tell). Constructive criticism welcome.