### PR TITLE
Update itoa.c for -std=c++17 compatibility

### DIFF
--- a/cores/nRF5/itoa.c
+++ b/cores/nRF5/itoa.c
@@ -23,6 +23,55 @@
 extern "C" {
 #endif
 
+/* reverse:  reverse string s in place */
+/*
+static void reverse( char s[] )
+{
+  int i, j ;
+  char c ;
+
+  for ( i = 0, j = strlen(s)-1 ; i < j ; i++, j-- )
+  {
+    c = s[i] ;
+    s[i] = s[j] ;
+    s[j] = c ;
+  }
+}
+*/
+
+/* itoa:  convert n to characters in s */
+/*
+extern void itoa( int n, char s[] )
+{
+  int i, sign ;
+
+  if ( (sign = n) < 0 )  // record sign
+  {
+    n = -n;          // make n positive
+  }
+
+  i = 0;
+  do
+  {       // generate digits in reverse order
+    s[i++] = n % 10 + '0';   // get next digit
+  } while ((n /= 10) > 0) ;     // delete it
+
+  if (sign < 0 )
+  {
+    s[i++] = '-';
+  }
+
+  s[i] = '\0';
+
+  reverse( s ) ;
+}
+*/
+
+extern char* itoa( int value, char *string, int radix )
+{
+  return ltoa( value, string, radix ) ;
+}
+
 extern char* ltoa( long value, char *string, int radix )
 {
   char tmp[33];
@@ -71,6 +120,11 @@ extern char* ltoa( long value, char *string, int radix )
   *sp = 0;
 
   return string;
+}
+
+extern char* utoa( unsigned int value, char *string, int radix )
+{
+  return ultoa( value, string, radix ) ;
 }
 
 extern char* ultoa( unsigned long value, char *string, int radix )

--- a/cores/nRF5/itoa.h
+++ b/cores/nRF5/itoa.h
@@ -22,9 +22,14 @@
 extern "C"{
 #endif
 
+//extern void itoa( int n, char s[] ) ;
+
+extern char* itoa( int value, char *string, int radix ) ;
 extern char* ltoa( long value, char *string, int radix ) ;
+extern char* utoa( unsigned int value, char *string, int radix ) ;
 extern char* ultoa( unsigned long value, char *string, int radix ) ;
 
 #ifdef __cplusplus
 } // extern "C"
 #endif
+


### PR DESCRIPTION
This change copies over itoa.h and itoa.c from https://github.com/adafruit/ArduinoCore-samd/tree/master/cores/arduino

This adds in the missing utoa and itoa functions when compiling using -std=c++17. This nRF52 core is currently using -std=gnu++11 in platform.txt so this isn't normally an issue.

Tested compiling a few example sketches successfully in the Arduino IDE with this change. Not tested on device, haven't ordered hardware yet.

I'm hoping to get this fixed to add support for building pigweed on top
of this core. See https://pigweed.dev/targets/arduino/target_docs.html if interested! :smile: 