### PR TITLE
Endian-swap implemented in setMajorMinor

### DIFF
--- a/libraries/Bluefruit52Lib/src/services/BLEBeacon.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEBeacon.cpp
@@ -77,8 +77,8 @@ void BLEBeacon::setUuid(uint8_t const uuid128[16])
 
 void BLEBeacon::setMajorMinor(uint16_t major, uint16_t minor)
 {
-  _major_be = major;
-  _minor_be = minor;
+  _major_be = __swap16(major);
+  _minor_be = __swap16(minor);
 }
 
 void BLEBeacon::setRssiAt1m(int8_t rssi)


### PR DESCRIPTION
The Endian-swap was missing on the BLEBeacon::setMajorMinor function. I was considering moving it into the start function, but as it was originally implemented in the constructor, I decided to add it to setMajorMinor instead.