### PR TITLE
follow up to PR-609

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -54,11 +54,8 @@ jobs:
         ln -s $GITHUB_WORKSPACE $HOME/$BSP_PATH/$BSP_VERSION
 
         # Install library dependency
-        arduino-cli lib install "Adafruit AHRS" "Adafruit APDS9960 Library" "Adafruit Arcada Library" "Adafruit BMP280 Library" "Adafruit Circuit Playground" "Adafruit EPD" "Adafruit GFX Library" "Adafruit HX8357 Library" "Adafruit ILI9341" "Adafruit LIS3MDL" "Adafruit LSM6DS" "Adafruit NeoPixel" "Adafruit NeoMatrix" "Adafruit Sensor Calibration" "Adafruit SHT31 Library" "Adafruit SSD1306" "Adafruit ST7735 and ST7789 Library" "SdFat - Adafruit Fork"
+        arduino-cli lib install "Adafruit AHRS" "Adafruit APDS9960 Library" "Adafruit Arcada Library" "Adafruit BMP280 Library" "Adafruit Circuit Playground" "Adafruit EPD" "Adafruit GFX Library" "Adafruit HX8357 Library" "Adafruit ILI9341" "Adafruit LIS3MDL" "Adafruit LSM6DS" "Adafruit NeoPixel" "Adafruit NeoMatrix" "Adafruit Sensor Calibration" "Adafruit SHT31 Library" "Adafruit SSD1306" "Adafruit ST7735 and ST7789 Library" "MIDI Library" "SdFat - Adafruit Fork"
         
-        # TODO update to support MIDI version 5 later on
-        arduino-cli lib install "MIDI Library"@4.3.1
-
         # TODO use firmata master to prevent build error with gcc v9 (should be remove after 2.5.9 is released)
         # https://github.com/firmata/arduino/pull/438
         git clone --depth 1 https://github.com/firmata/arduino.git $HOME/Arduino/libraries/firmata

--- a/libraries/Bluefruit52Lib/src/services/BLEMidi.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEMidi.cpp
@@ -161,7 +161,7 @@ err_t BLEMidi::begin(void)
   return ERROR_NONE;
 }
   
-bool BLEMidi::beginTransmission(MIDI_NAMESPACE::MidiType type)
+bool BLEMidi::beginTransmission(uint8_t type)
 {
   return true;
 };

--- a/libraries/Bluefruit52Lib/src/services/BLEMidi.h
+++ b/libraries/Bluefruit52Lib/src/services/BLEMidi.h
@@ -35,8 +35,6 @@
 #ifndef BLEMIDI_H_
 #define BLEMIDI_H_
 
-#include <MIDI.h>
-
 #include "bluefruit_common.h"
 #include "utility/adafruit_fifo.h"
 
@@ -76,7 +74,7 @@ class BLEMidi: public BLEService, public Stream
     void setWriteCallback(midi_write_cb_t fp);
     void autoMIDIread(void* midi_obj);
 
-    bool beginTransmission(MIDI_NAMESPACE::MidiType type);
+    bool beginTransmission(uint8_t type);
     void endTransmission();
 
     // Stream API for MIDI Interface


### PR DESCRIPTION
- remove the include MIDI.h to prevent build error without MIDI Library installed
- update ci to use MIDI v5