### PR TITLE
Arduino BLE Gamepad support

### DIFF
--- a/libraries/Bluefruit52Lib/examples/Peripheral/hid_gamepad/hid_gamepad.ino
+++ b/libraries/Bluefruit52Lib/examples/Peripheral/hid_gamepad/hid_gamepad.ino
@@ -1,0 +1,190 @@
+/*********************************************************************
+ This is an example for our nRF52 based Bluefruit LE modules
+
+ Pick one up today in the adafruit shop!
+
+ Adafruit invests time and resources providing this open source code,
+ please support Adafruit and open-source hardware by purchasing
+ products from Adafruit!
+
+ MIT license, check LICENSE for more information
+ All text above, and the splash screen below must be included in
+ any redistribution
+*********************************************************************/
+#include <bluefruit.h>
+
+BLEDis bledis;
+BLEHidAdafruit blehid;
+
+hid_gamepad_report_t gp;        // defined in hid.h from Adafruit_TinyUSB_ArduinoCore
+hid_gamepad_button_bm_t bbm;    // defined in hid.h from Adafruit_TinyUSB_ArduinoCore
+
+void setup() 
+{
+  Serial.begin(115200);
+  while ( !Serial ) delay(10);   // for nrf52840 with native usb
+
+  Serial.println("Bluefruit52 HID Gamepad Example");
+  Serial.println("-----------------------------\n");
+  Serial.println("Go to your phone's Bluetooth settings to pair your device");
+  Serial.println("then open an application that accepts mouse input");
+  Serial.println();
+
+  Bluefruit.begin();
+
+  // HID Device can have a min connection interval of 9*1.25 = 11.25 ms
+  Bluefruit.Periph.setConnInterval(9, 16); // min = 9*1.25=11.25 ms, max = 16*1.25=20ms
+  Bluefruit.setTxPower(4);                 // Check bluefruit.h for supported values
+  Bluefruit.setName("nRF52 Gamepad");
+
+  // Configure and Start Device Information Service
+  bledis.setManufacturer("Adafruit Industries");
+  bledis.setModel("Bluefruit Feather 52");
+  bledis.begin();
+
+  // BLE HID
+  blehid.begin();
+
+  // Set up and start advertising
+  // Advertising packet
+  Bluefruit.Advertising.addFlags(BLE_GAP_ADV_FLAGS_LE_ONLY_GENERAL_DISC_MODE);
+  Bluefruit.Advertising.addTxPower();
+  Bluefruit.Advertising.addAppearance(BLE_APPEARANCE_HID_GAMEPAD);
+
+  // Include BLE HID service
+  Bluefruit.Advertising.addService(blehid);
+
+  // There is enough room for 'Name' in the advertising packet
+  Bluefruit.Advertising.addName();
+
+  /* Start Advertising
+   * - Enable auto advertising if disconnected
+   * - Interval:  fast mode = 20 ms, slow mode = 152.5 ms
+   * - Timeout for fast mode is 30 seconds
+   * - Start(timeout) with timeout = 0 will advertise forever (until connected)
+   * 
+   * For recommended advertising interval
+   * https://developer.apple.com/library/content/qa/qa1931/_index.html   
+   */
+  Bluefruit.Advertising.restartOnDisconnect(true);
+  Bluefruit.Advertising.setInterval(32, 244);    // in unit of 0.625 ms
+  Bluefruit.Advertising.setFastTimeout(30);      // number of seconds in fast mode
+  Bluefruit.Advertising.start(0);                // 0 = Don't stop advertising after n seconds
+
+  Serial.print("Attempting to connect");
+  uint8_t i=0;
+  while(! Bluefruit.connected()) { 
+    Serial.print("."); delay(100);
+    if((++i)>50) {
+      i=0; Serial.println();
+    }
+  };
+  delay(1000);//just in case
+  Serial.println("\nConnection successful");
+}
+
+void loop() 
+{    
+  // Reset buttons
+  Serial.println("No pressing buttons");
+  gp.buttons = 0;
+  gp.x       = 0;
+  gp.y       = 0;
+  gp.z       = 0;
+  gp.r_z     = 0;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+
+  
+  // Joystick 1 UP
+  Serial.println("Joystick 1 UP");
+  gp.x = 0;
+  gp.y = -127;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+  
+  // Joystick 1 DOWN
+  Serial.println("Joystick 1 DOWN");
+  gp.x = 0;
+  gp.y = 127;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+
+  // Joystick 1 LEFT
+  Serial.println("Joystick 1 LEFT");
+  gp.x = -127;
+  gp.y = 0;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+
+  // Joystick 1 RIGHT
+  Serial.println("Joystick 1 RIGHT");
+  gp.x = 127;
+  gp.y = 0;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+
+  // Joystick 1 CENTER
+  Serial.println("Joystick 1 CENTER");
+  gp.x = 0;
+  gp.y = 0;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+
+
+  // Joystick 2 UP
+  Serial.println("Joystick 2 UP");
+  gp.z   = 0;
+  gp.r_z = 127;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+  
+  // Joystick 2 DOWN
+  Serial.println("Joystick 2 DOWN");
+  gp.z   = 0;
+  gp.r_z = -127;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+
+  // Joystick 2 LEFT
+  Serial.println("Joystick 2 LEFT");
+  gp.z   = -127;
+  gp.r_z = 0;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+
+  // Joystick 2 RIGHT
+  Serial.println("Joystick 2 RIGHT");
+  gp.z   = 127;
+  gp.r_z = 0;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+
+  // Joystick 2 CENTER
+  Serial.println("Joystick 2 CENTER");
+  gp.z   = 0;
+  gp.r_z = 0;
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+
+  
+  // Test buttons
+  for (int i=0; i<=15; ++i)
+  {
+    Serial.print("Pressing button "); Serial.println(i+1);
+    gp.buttons = (0x00 | TU_BIT(i));
+    blehid.gamepadReport(0, &gp);
+    delay(1000);
+  }
+
+
+  // Random touch
+  Serial.println("Random touch");
+  gp.buttons = random(0, 0xffff);
+  gp.x       = random(-127, 128);
+  gp.y       = random(-127, 128);
+  gp.z       = random(-127, 128);
+  gp.r_z     = random(-127, 128);
+  blehid.gamepadReport(0, &gp);
+  delay(2000);
+}

--- a/libraries/Bluefruit52Lib/src/BLEDiscovery.h
+++ b/libraries/Bluefruit52Lib/src/BLEDiscovery.h
@@ -101,6 +101,12 @@ class BLEDiscovery
       return discoverCharacteristic(conn_handle, chr_arr, arrcount(chr_arr));
     }
 
+    uint8_t  discoverCharacteristic(uint16_t conn_handle, BLEClientCharacteristic& chr1, BLEClientCharacteristic& chr2, BLEClientCharacteristic& chr3, BLEClientCharacteristic& chr4, BLEClientCharacteristic& chr5, BLEClientCharacteristic& chr6, BLEClientCharacteristic& chr7)
+    {
+      BLEClientCharacteristic* chr_arr[] = {&chr1, &chr2, &chr3, &chr4, &chr5, &chr6, &chr7};
+      return discoverCharacteristic(conn_handle, chr_arr, arrcount(chr_arr));
+    }
+
     /*------------------------------------------------------------------*/
     /* INTERNAL USAGE ONLY
      * Although declare as public, it is meant to be invoked by internal

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientHidAdafruit.cpp
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientHidAdafruit.cpp
@@ -41,12 +41,14 @@ BLEClientHidAdafruit::BLEClientHidAdafruit(void)
    _protcol_mode(UUID16_CHR_PROTOCOL_MODE),
    _hid_info(UUID16_CHR_HID_INFORMATION), _hid_control(UUID16_CHR_HID_CONTROL_POINT),
    _kbd_boot_input(UUID16_CHR_BOOT_KEYBOARD_INPUT_REPORT), _kbd_boot_output(UUID16_CHR_BOOT_KEYBOARD_OUTPUT_REPORT),
-   _mse_boot_input(UUID16_CHR_BOOT_MOUSE_INPUT_REPORT)
+   _mse_boot_input(UUID16_CHR_BOOT_MOUSE_INPUT_REPORT), _gpd_boot_input(UUID16_CHR_HID_INFORMATION)
 {
   _kbd_cb = NULL;
   _mse_cb = NULL;
+  _gpd_cb = NULL;
   varclr(&_last_kbd_report);
   varclr(&_last_mse_report);
+  varclr(&_last_gpd_report);
 }
 
 
@@ -62,6 +64,11 @@ void mse_client_notify_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t 
   svc._handle_mse_input(data, len);
 }
 
+void gpd_client_notify_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len)
+{
+  BLEClientHidAdafruit& svc = (BLEClientHidAdafruit&) chr->parentService();
+  svc._handle_gpd_input(data, len);
+}
 
 bool BLEClientHidAdafruit::begin(void)
 {
@@ -77,10 +84,12 @@ bool BLEClientHidAdafruit::begin(void)
 
   _mse_boot_input.begin(this);
 
+  _gpd_boot_input.begin(this);
 
   // set notify callback
   _kbd_boot_input.setNotifyCallback(kbd_client_notify_cb);
   _mse_boot_input.setNotifyCallback(mse_client_notify_cb);
+  _gpd_boot_input.setNotifyCallback(gpd_client_notify_cb);
 
   return true;
 }
@@ -95,6 +104,11 @@ void BLEClientHidAdafruit::setMouseReportCallback(mse_callback_t fp)
   _mse_cb = fp;
 }
 
+void BLEClientHidAdafruit::setGamepadReportCallback(gpd_callback_t fp)
+{
+  _gpd_cb = fp;
+}
+
 bool BLEClientHidAdafruit::discover(uint16_t conn_handle)
 {
   // Call Base class discover
@@ -102,10 +116,10 @@ bool BLEClientHidAdafruit::discover(uint16_t conn_handle)
   _conn_hdl = BLE_CONN_HANDLE_INVALID; // make as invalid until we found all chars
 
   // Discover all characteristics
-  Bluefruit.Discovery.discoverCharacteristic(conn_handle, _protcol_mode, _kbd_boot_input, _kbd_boot_output, _mse_boot_input, _hid_info, _hid_control);
+  Bluefruit.Discovery.discoverCharacteristic(conn_handle, _protcol_mode, _kbd_boot_input, _kbd_boot_output, _mse_boot_input, _gpd_boot_input, _hid_info, _hid_control);
 
   VERIFY( _protcol_mode.discovered() && _hid_info.discovered() && _hid_control.discovered() );
-  VERIFY ( keyboardPresent() || mousePresent() );
+  VERIFY ( keyboardPresent() || mousePresent() || gamepadPresent() );
 
   _conn_hdl = conn_handle;
   return true;
@@ -195,3 +209,33 @@ void BLEClientHidAdafruit::getMouseReport(hid_mouse_report_t* report)
   memcpy(report, &_last_mse_report, sizeof(hid_mouse_report_t));
 }
 
+/*------------------------------------------------------------------*/
+/* Gamepad
+ *------------------------------------------------------------------*/
+bool BLEClientHidAdafruit::gamepadPresent(void)
+{
+  return _gpd_boot_input.discovered();
+}
+
+bool BLEClientHidAdafruit::enableGamepad(void)
+{
+  return _gpd_boot_input.enableNotify();
+}
+
+bool BLEClientHidAdafruit::disableGamepad(void)
+{
+  return _gpd_boot_input.disableNotify();
+}
+
+void BLEClientHidAdafruit::_handle_gpd_input(uint8_t* data, uint16_t len)
+{
+  varclr(&_last_gpd_report);
+  memcpy(&_last_gpd_report, data, len);
+
+  if ( _gpd_cb ) _gpd_cb(&_last_gpd_report);
+}
+
+void BLEClientHidAdafruit::getGamepadReport(hid_gamepad_report_t* report)
+{
+  memcpy(report, &_last_gpd_report, sizeof(hid_gamepad_report_t));
+}

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientHidAdafruit.h
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientHidAdafruit.h
@@ -49,6 +49,7 @@ class BLEClientHidAdafruit : public BLEClientService
     // Callback Signatures
     typedef void (*kbd_callback_t ) (hid_keyboard_report_t* report);
     typedef void (*mse_callback_t ) (hid_mouse_report_t* report);
+    typedef void (*gpd_callback_t ) (hid_gamepad_report_t* report);
 
     BLEClientHidAdafruit(void);
 
@@ -74,16 +75,26 @@ class BLEClientHidAdafruit : public BLEClientService
 
     void getMouseReport(hid_mouse_report_t* report);
 
+    // Gamepad API
+    bool gamepadPresent(void);
+    bool enableGamepad(void);
+    bool disableGamepad(void);
+
+    void getGamepadReport(hid_gamepad_report_t* report);
+
     // Report callback
     void setKeyboardReportCallback(kbd_callback_t fp);
     void setMouseReportCallback(mse_callback_t fp);
+    void setGamepadReportCallback(gpd_callback_t fp);
 
   protected:
     kbd_callback_t _kbd_cb;
     mse_callback_t _mse_cb;
+    gpd_callback_t _gpd_cb;
 
     hid_keyboard_report_t _last_kbd_report;
     hid_mouse_report_t    _last_mse_report;
+    hid_gamepad_report_t  _last_gpd_report;
 
     // Only support Boot protocol for keyboard and Mouse
     BLEClientCharacteristic _protcol_mode;
@@ -95,11 +106,15 @@ class BLEClientHidAdafruit : public BLEClientService
 
     BLEClientCharacteristic _mse_boot_input;
 
+    BLEClientCharacteristic _gpd_boot_input;
+
     void _handle_kbd_input(uint8_t* data, uint16_t len);
     void _handle_mse_input(uint8_t* data, uint16_t len);
+    void _handle_gpd_input(uint8_t* data, uint16_t len);
 
     friend void kbd_client_notify_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len);
     friend void mse_client_notify_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len);
+    friend void gpd_client_notify_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len);
 };
 
 

--- a/libraries/Bluefruit52Lib/src/services/BLEHidAdafruit.h
+++ b/libraries/Bluefruit52Lib/src/services/BLEHidAdafruit.h
@@ -106,8 +106,18 @@ class BLEHidAdafruit : public BLEHidGeneric
     bool mouseScroll(uint16_t conn_hdl, int8_t scroll);
     bool mousePan(uint16_t conn_hdl, int8_t pan);
 
+    //------------- Gamepad -------------//
+    // Single connection
+    bool gamepadReport(hid_gamepad_report_t* report);
+    bool gamepadReport(uint16_t buttons, int8_t x=0, int8_t y=0, int8_t z=0, int8_t r_z=0);
+
+    // Multiple connections
+    bool gamepadReport(uint16_t conn_hdl, hid_gamepad_report_t* report);
+    bool gamepadReport(uint16_t conn_hdl, uint16_t buttons, int8_t x=0, int8_t y=0, int8_t z=0, int8_t r_z=0);
+
   protected:
-    uint8_t _mse_buttons;
+    uint8_t  _mse_buttons;
+    uint16_t _gpd_buttons;
     kbd_led_cb_t _kbd_led_cb;
 
     static void blehid_ada_keyboard_output_cb(uint16_t conn_hdl, BLECharacteristic* chr, uint8_t* data, uint16_t len);

--- a/libraries/Bluefruit52Lib/src/services/BLEHidGeneric.h
+++ b/libraries/Bluefruit52Lib/src/services/BLEHidGeneric.h
@@ -53,20 +53,6 @@ typedef struct ATTR_PACKED
   uint16_t usage_value; ///< Usage value of the pressed control
 } hid_consumer_control_report_t;
 
-/// Gamepad report
-typedef struct ATTR_PACKED
-{
-  struct ATTR_PACKED
-  {
-    uint8_t x : 2;
-    uint8_t y : 2;
-    uint8_t : 4;
-  };
-
-  uint8_t buttons;
-}hid_gamepad_report_t;
-
-
 class BLEHidGeneric : public BLEService
 {
   public:
@@ -74,6 +60,7 @@ class BLEHidGeneric : public BLEService
 
     void enableKeyboard(bool enable);
     void enableMouse(bool enable);
+    void enableGamepad(bool enable);
 
     void setHidInfo(uint16_t bcd, uint8_t country, uint8_t flags);
 
@@ -90,11 +77,13 @@ class BLEHidGeneric : public BLEService
     bool inputReport(uint8_t reportID, void const* data, int len);
     bool bootKeyboardReport(void const* data, int len);
     bool bootMouseReport(void const* data, int len);
+    bool bootGamepadReport(void const* data, int len);
 
     // Send report to specific connection
     bool inputReport(uint16_t conn_hdl, uint8_t reportID, void const* data, int len);
     bool bootKeyboardReport(uint16_t conn_hdl, void const* data, int len);
     bool bootMouseReport(uint16_t conn_hdl, void const* data, int len);
+    bool bootGamepadReport(uint16_t conn_hdl, void const* data, int len);
 
   protected:
     uint8_t _num_input;
@@ -103,6 +92,7 @@ class BLEHidGeneric : public BLEService
 
     bool    _has_keyboard;
     bool    _has_mouse;
+    bool    _has_gamepad;
     bool    _report_mode;
 
     uint8_t _hid_info[4];
@@ -122,6 +112,8 @@ class BLEHidGeneric : public BLEService
     BLECharacteristic* _chr_boot_keyboard_input;
     BLECharacteristic* _chr_boot_keyboard_output;
     BLECharacteristic* _chr_boot_mouse_input;
+
+    BLECharacteristic* _chr_boot_gamepad_input;
 
     BLECharacteristic _chr_control;
 


### PR DESCRIPTION
This is a basic draft to get BLE Gamepad support in Adafruit nRF52 devices. I based the Gamepad code on Mouse code as both peripherals are so similar. I'm not sure about lines `BLECLientHidAdafruit.cpp:44` and` BLEHidGeneric.cpp:248` as I used `UUID16_CHR_BOOT_MOUSE_INPUT_REPORT` constant as 16 bit UUID for gamepad, but it works. Here some considerations:

- It's needed to add some little changes on `hid.h` file from `Adafruit_TinyUSB_ArduinoCore` repo. See PR #20 from `adafruit/Adafruit_TinyUSB_ArduinoCore` repo.
- This may will solve #228. 
- There is no support for HAT buttons, but I can try to implement it if needed. It would be necessary to modify again all these files.