### PR TITLE
Added support for passkey-entry and made some usability improvements

### DIFF
--- a/libraries/Bluefruit52Lib/src/BLEPeriph.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEPeriph.cpp
@@ -78,6 +78,11 @@ uint8_t BLEPeriph::connected (void)
   return count;
 }
 
+bool BLEPeriph::getBonds(bonded_device_info* bondedPeers, uint32_t bondedPeersSize, uint32_t* actualBondedPeersSize)
+{
+  return bond_get_list(BLE_GAP_ROLE_PERIPH, bondedPeers, bondedPeersSize, actualBondedPeersSize);
+}
+
 void BLEPeriph::clearBonds(void)
 {
   bond_clear_prph();

--- a/libraries/Bluefruit52Lib/src/BLEPeriph.h
+++ b/libraries/Bluefruit52Lib/src/BLEPeriph.h
@@ -39,6 +39,7 @@
 
 #include <Arduino.h>
 #include "bluefruit_common.h"
+#include "utility/bonding.h"
 
 class BLEPeriph
 {
@@ -50,6 +51,7 @@ class BLEPeriph
     bool    connected(uint16_t conn_hdl); // Connected as prph to this connection
     uint8_t connected(void);              // Number of connected as peripherals
 
+    bool getBonds(bonded_device_info* bondedPeers, uint32_t bondedPeersSize, uint32_t* actualBondedPeersSize);
     void clearBonds(void);
 
     bool setConnInterval   (uint16_t min, uint16_t max);

--- a/libraries/Bluefruit52Lib/src/BLESecurity.cpp
+++ b/libraries/Bluefruit52Lib/src/BLESecurity.cpp
@@ -76,10 +76,16 @@ static void _passkey_display_cabllack_dfr(BLESecurity::pair_passkey_cb_t func, u
   }
 }
 
+static void _passkey_request_callback_dfr(BLESecurity::pair_passkey_req_cb_t func, uint16_t conn_hdl)
+{
+  func(conn_hdl);
+}
+
 BLESecurity::BLESecurity(void)
 {
   _sec_param = _sec_param_default;
   _passkey_cb = NULL;
+  _passkey_req_cb = NULL;
   _complete_cb = NULL;
   _secured_cb = NULL;
 }
@@ -207,6 +213,11 @@ bool BLESecurity::setPairPasskeyCallback(pair_passkey_cb_t fp)
   return true;
 }
 
+void BLESecurity::setPairPasskeyRequestedCallback(pair_passkey_req_cb_t fp)
+{
+  _passkey_req_cb = fp;
+}
+
 void BLESecurity::setPairCompleteCallback(pair_complete_cb_t fp)
 {
   _complete_cb = fp;
@@ -215,6 +226,12 @@ void BLESecurity::setPairCompleteCallback(pair_complete_cb_t fp)
 void BLESecurity::setSecuredCallback(secured_conn_cb_t fp)
 {
  _secured_cb = fp;
+}
+
+bool BLESecurity::enterRequestedPasskey(uint16_t conn_hdl, uint8_t const* passkey)
+{
+  VERIFY_STATUS(sd_ble_gap_auth_key_reply(conn_hdl, BLE_GAP_AUTH_KEY_TYPE_PASSKEY, passkey), false);
+  return true;
 }
 
 bool BLESecurity::_authenticate(uint16_t conn_hdl)
@@ -305,6 +322,16 @@ void BLESecurity::_eventHandler(ble_evt_t* evt)
        {
          ada_callback(passkey_display->passkey, 6, _passkey_display_cabllack_dfr, _passkey_cb, conn_hdl, passkey_display->passkey, passkey_display->match_request);
        }
+    }
+    break;
+
+    case BLE_GAP_EVT_AUTH_KEY_REQUEST:
+    {
+      LOG_LV2("PAIR", "Passkey requested");
+      if (_passkey_req_cb)
+      {
+        ada_callback(NULL, 0, _passkey_request_callback_dfr, _passkey_req_cb, conn_hdl);
+      }
     }
     break;
 

--- a/libraries/Bluefruit52Lib/src/BLESecurity.h
+++ b/libraries/Bluefruit52Lib/src/BLESecurity.h
@@ -36,6 +36,7 @@ class BLESecurity
 {
   public:
     typedef bool (*pair_passkey_cb_t ) (uint16_t conn_hdl, uint8_t const passkey[6], bool match_request);
+    typedef void (*pair_passkey_req_cb_t) (uint16_t conn_hdl);
     typedef void (*pair_complete_cb_t) (uint16_t conn_hdl, uint8_t auth_status);
     typedef void (*secured_conn_cb_t) (uint16_t conn_hdl);
 
@@ -57,8 +58,11 @@ class BLESecurity
 
     //------------- Callbacks -------------//
     bool setPairPasskeyCallback(pair_passkey_cb_t fp);
+    void setPairPasskeyRequestedCallback(pair_passkey_req_cb_t fp);
     void setPairCompleteCallback(pair_complete_cb_t fp);
     void setSecuredCallback(secured_conn_cb_t fp);
+
+    bool enterRequestedPasskey(uint16_t conn_hdl, uint8_t const* passkey);
 
     /*------------------------------------------------------------------*/
     /* INTERNAL USAGE ONLY
@@ -82,6 +86,7 @@ class BLESecurity
     bond_keys_t  _bond_keys; // Shared keys with bonded device during securing connection, size ~ 80 bytes
 
     pair_passkey_cb_t  _passkey_cb;
+    pair_passkey_req_cb_t _passkey_req_cb;
     pair_complete_cb_t _complete_cb;
     secured_conn_cb_t  _secured_cb;
 };

--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -607,6 +607,21 @@ bool AdafruitBluefruit::connected(uint16_t conn_hdl)
   return conn && conn->connected();
 }
 
+void AdafruitBluefruit::getConnectionHandles(uint16_t* connectionHandles, uint8_t maxConnectionHandleCount, uint8_t* actualConnectionHandleCount)
+{
+  uint8_t count = 0;
+  for (uint16_t connectionHandle = 0; (connectionHandle < BLE_MAX_CONNECTION) && (count < maxConnectionHandleCount); ++connectionHandle)
+  {
+    if (this->connected(connectionHandle))
+    {
+      connectionHandles[count] = connectionHandle;
+      count++;
+    }
+  }
+
+  *actualConnectionHandleCount = count;
+}
+
 bool AdafruitBluefruit::disconnect(uint16_t conn_hdl)
 {
   BLEConnection* conn = this->Connection(conn_hdl);

--- a/libraries/Bluefruit52Lib/src/bluefruit.h
+++ b/libraries/Bluefruit52Lib/src/bluefruit.h
@@ -163,6 +163,8 @@ class AdafruitBluefruit
     uint8_t  connected         (void); // Number of connected
     bool     connected         (uint16_t conn_hdl);
 
+    void getConnectionHandles(uint16_t* connectionHandles, uint8_t maxConnectionHandleCount, uint8_t* actualConnectionHandleCount);
+
     uint16_t connHandle        (void);
 
     // Alias to BLEConnection API()

--- a/libraries/Bluefruit52Lib/src/services/BLEHidAdafruit.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEHidAdafruit.cpp
@@ -225,6 +225,16 @@ bool BLEHidAdafruit::mouseButtonRelease(uint16_t conn_hdl)
   return mouseReport(conn_hdl, 0, 0, 0, 0, 0);
 }
 
+bool BLEHidAdafruit::mouseButtonPressSpecific(uint16_t conn_hdl, uint8_t buttons)
+{
+  return mouseReport(conn_hdl, _mse_buttons | buttons, 0, 0, 0, 0);
+}
+
+bool BLEHidAdafruit::mouseButtonReleaseSpecific(uint16_t conn_hdl, uint8_t buttons)
+{
+  return mouseReport(conn_hdl, _mse_buttons & ~buttons, 0, 0, 0, 0);
+}
+
 bool BLEHidAdafruit::mouseMove(uint16_t conn_hdl, int8_t x, int8_t y)
 {
   return mouseReport(conn_hdl, _mse_buttons, x, y, 0, 0);
@@ -305,6 +315,16 @@ bool BLEHidAdafruit::mouseButtonPress(uint8_t buttons)
 bool BLEHidAdafruit::mouseButtonRelease(void)
 {
   return mouseButtonRelease(BLE_CONN_HANDLE_INVALID);
+}
+
+bool BLEHidAdafruit::mouseButtonPressSpecific(uint8_t buttons)
+{
+  return mouseButtonPressSpecific(BLE_CONN_HANDLE_INVALID, buttons);
+}
+
+bool BLEHidAdafruit::mouseButtonReleaseSpecific(uint8_t buttons)
+{
+  return mouseButtonReleaseSpecific(BLE_CONN_HANDLE_INVALID, buttons);
 }
 
 bool BLEHidAdafruit::mouseMove(int8_t x, int8_t y)

--- a/libraries/Bluefruit52Lib/src/services/BLEHidAdafruit.h
+++ b/libraries/Bluefruit52Lib/src/services/BLEHidAdafruit.h
@@ -90,6 +90,9 @@ class BLEHidAdafruit : public BLEHidGeneric
 
     bool mouseButtonPress(uint8_t buttons);
     bool mouseButtonRelease(void);
+    
+    bool mouseButtonPressSpecific(uint8_t buttons);
+    bool mouseButtonReleaseSpecific(uint8_t buttons);
 
     bool mouseMove(int8_t x, int8_t y);
     bool mouseScroll(int8_t scroll);
@@ -101,6 +104,9 @@ class BLEHidAdafruit : public BLEHidGeneric
 
     bool mouseButtonPress(uint16_t conn_hdl, uint8_t buttons);
     bool mouseButtonRelease(uint16_t conn_hdl);
+    
+    bool mouseButtonPressSpecific(uint16_t conn_hdl, uint8_t buttons);
+    bool mouseButtonReleaseSpecific(uint16_t conn_hdl, uint8_t buttons);
 
     bool mouseMove(uint16_t conn_hdl, int8_t x, int8_t y);
     bool mouseScroll(uint16_t conn_hdl, int8_t scroll);

--- a/libraries/Bluefruit52Lib/src/utility/bonding.cpp
+++ b/libraries/Bluefruit52Lib/src/utility/bonding.cpp
@@ -292,6 +292,47 @@ bool bond_load_cccd(uint8_t role, uint16_t conn_hdl, ble_gap_addr_t const* id_ad
   return loaded;
 }
 
+bool bond_get_list(uint8_t role, bonded_device_info* bondedPeers, uint32_t bondedPeersSize, uint32_t* actualBondedPeersSize)
+{
+  char const * dpath = (role == BLE_GAP_ROLE_PERIPH ? BOND_DIR_PRPH : BOND_DIR_CNTR);
+
+  File dir(dpath, FILE_O_READ, InternalFS);
+  File file(InternalFS);
+
+  uint32_t peerIndex = 0;
+  while ((file = dir.openNextFile(FILE_O_READ)) && (peerIndex < bondedPeersSize))
+  {
+    if (!file.isDirectory())
+    {
+      int len = file.read();
+      bond_keys_t bondKeys{};
+      if (len == sizeof(bondKeys))
+      {
+        file.read(&bondKeys, len);
+
+        bonded_device_info deviceInfo{};
+        deviceInfo.address = bondKeys.peer_id.id_addr_info;
+
+        len = file.read();
+        if (len > 0)
+        {
+          file.read(deviceInfo.name, min(len, sizeof(deviceInfo.name)));
+        }
+
+        bondedPeers[peerIndex] = deviceInfo;
+        peerIndex++;
+      }
+    }
+
+    file.close();
+  }
+
+  file.close();
+  dir.close();
+  *actualBondedPeersSize = peerIndex;
+  return true;
+}
+
 void bond_print_list(uint8_t role)
 {
   char const * dpath = (role == BLE_GAP_ROLE_PERIPH ? BOND_DIR_PRPH : BOND_DIR_CNTR);

--- a/libraries/Bluefruit52Lib/src/utility/bonding.h
+++ b/libraries/Bluefruit52Lib/src/utility/bonding.h
@@ -52,6 +52,12 @@ typedef struct
   ble_gap_id_key_t  peer_id;
 } bond_keys_t;
 
+typedef struct
+{
+  ble_gap_addr_t address;
+  char name[25];
+} bonded_device_info;
+
 void bond_init(void);
 void bond_clear_prph(void);
 void bond_clear_cntr(void);
@@ -65,6 +71,7 @@ bool bond_load_keys(uint8_t role, ble_gap_addr_t* peer_addr, bond_keys_t* bkeys)
 bool bond_save_cccd (uint8_t role, uint16_t conn_hdl, ble_gap_addr_t const* id_addr);
 bool bond_load_cccd (uint8_t role, uint16_t conn_hdl, ble_gap_addr_t const* id_addr);
 
+bool bond_get_list(uint8_t role, bonded_device_info* bondedPeers, uint32_t bondedPeersSize, uint32_t* actualBondedPeersSize);
 void bond_print_list(uint8_t role);
 
 #endif /* BONDING_H_ */


### PR DESCRIPTION
Our use cases required some additional functionality to exercise passkey-entry pairing, have more control over mouse button press/release, and have more ways to query for current bonds and connections.

These are meant to be some spot-changes that don't modify any existing behavior but can be used to unblock certain uses. Hopefully they can be useful to others.

**Quick summary:**
- Added support for `Passkey Entry` pairing by handling `BLE_GAP_EVT_AUTH_KEY_REQUEST` in `BLESecurity` class.
- Added a couple of functions to `BLEHidAdafruit` such that specific mouse buttons can be released (not necessarily all of them at once) and pressed (without affecting the state of buttons already being pressed).
- Added helper to bonding.h/cpp to get a list of bonded peers, not just print them.
- Added function to `BLEPeriph` to call the new helper to get bonded peers for peripheral role.
- Added function to `AdafruitBluefruit` to get all currently connected connection handles.
