### PR TITLE
updated linker script to fix recurring issue with .bss linker warning

### DIFF
--- a/cores/nRF5/linker/nrf52_common.ld
+++ b/cores/nRF5/linker/nrf52_common.ld
@@ -138,7 +138,7 @@ SECTIONS
 
     } > RAM
 
-    .bss :
+    .bss ALIGN(4):
     {
         . = ALIGN(4);
         __bss_start__ = .;


### PR DESCRIPTION
This update to the "nrf52_common.ld" linker script fixes the linker warning **warning: changing start of section .bss by 4 bytes** which is given to sketches that contain lots of static/global data.