### PR TITLE
Fix to atomic compiler errors

### DIFF
--- a/cores/nRF5/HardwarePWM.h
+++ b/cores/nRF5/HardwarePWM.h
@@ -39,6 +39,7 @@
 #include "common_inc.h"
 #include "nrf.h"
 #include <atomic>
+#include <cstdint>
 
 #ifdef NRF52840_XXAA
 #define HWPWM_MODULE_NUM    4
@@ -51,7 +52,7 @@ class HardwarePWM
   private:
     enum { MAX_CHANNELS = 4 }; // Max channel per group
     NRF_PWM_Type * const _pwm;
-    std::atomic_uint32_t _owner_token;
+    std::atomic<std::uint32_t> _owner_token;
 
     uint16_t _seq0[MAX_CHANNELS];
 


### PR DESCRIPTION
This simple fix is to resolve the issue with compilation errors on "atomic_uint32_t".  This is an alias for std::atomic<std::uint32_t>.  When replacing it with the unaliased type, the errors are gone.