### PR TITLE
fix bonding with public/static address

### DIFF
--- a/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
+++ b/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
@@ -531,6 +531,7 @@ void BLECharacteristic::_eventHandler(ble_evt_t* event)
       {
         LOG_LV2("GATTS", "attr's value, uuid = 0x%04X, len = %d", request->uuid.uuid, request->len);
         LOG_LV2_BUFFER(NULL, request->data, request->len);
+        LOG_LV2(NULL, "\r\n");
 
         if (_wr_cb)
         {

--- a/libraries/Bluefruit52Lib/src/BLESecurity.cpp
+++ b/libraries/Bluefruit52Lib/src/BLESecurity.cpp
@@ -360,6 +360,13 @@ void BLESecurity::_eventHandler(ble_evt_t* evt)
       // Pairing succeeded --> save encryption keys ( Bonding )
       if (BLE_GAP_SEC_STATUS_SUCCESS == status->auth_status)
       {
+        if (!status->kdist_peer.id)
+        {
+          // Peer does not provide IRK, it is possible that device uses Public/Static address which
+          // IRK is not needed. We will use the connect address instead
+          _bond_keys.peer_id.id_addr_info = conn->getPeerAddr();
+        }
+
         conn->saveBondKey(&_bond_keys);
       }
 

--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -784,8 +784,14 @@ void AdafruitBluefruit::_ble_handler(ble_evt_t* evt)
       _setConnLed(true);
 
       ble_gap_evt_connected_t const * para = &evt->evt.gap_evt.params.connected;
+      ble_gap_addr_t const* peer_addr = &para->peer_addr;
 
-      LOG_LV1("GAP", "Conn Interval= %.2f ms, Latency = %d, Supervisor Timeout = %d ms",
+      (void) peer_addr;
+
+      LOG_LV2("GAP", "MAC = %02X:%02X:%02X:%02X:%02X:%02X, Type = %d, Resolved = %d",
+              peer_addr->addr[5], peer_addr->addr[4], peer_addr->addr[3], peer_addr->addr[2], peer_addr->addr[1], peer_addr->addr[0],
+              peer_addr->addr_type, peer_addr->addr_id_peer);
+      LOG_LV2("GAP", "Conn Interval = %.2f ms, Latency = %d, Supervisor Timeout = %d ms",
               para->conn_params.max_conn_interval*1.25f, para->conn_params.slave_latency, 10*para->conn_params.conn_sup_timeout);
 
       if ( _connection[conn_hdl] )


### PR DESCRIPTION
Fix issue when bonding with peer device using public address where the IRK+address are not exchanged when pairing (since device think it is not necessary). Should fix #670 