### PR TITLE
Allow common_func.h to compile without error when it is included inside extern "C"

### DIFF
--- a/cores/nRF5/common_func.h
+++ b/cores/nRF5/common_func.h
@@ -39,6 +39,7 @@
 
 
 #ifdef __cplusplus
+  extern "C++" {
   // namespace and templates must be outside the `extern "C"` declaration...
   namespace ADAFRUIT_DETAIL
   {
@@ -47,6 +48,7 @@
       {
           return N;
       }
+  }
   }
   extern "C" {
   #define arrcount(arr) ADAFRUIT_DETAIL::arrcount_fails_if_not_array(arr)


### PR DESCRIPTION
When a library includes something that includes common_func.h from inside an extern "C" {} block, compilation will fail. This is at least an infelicity. This PR forces C++ linking in the C++ only parts of common_func.h allowing it to compile without mysterious failures.