### PR TITLE
Add the ability to change SAADC acquisition time

### DIFF
--- a/cores/nRF5/wiring_analog.h
+++ b/cores/nRF5/wiring_analog.h
@@ -107,6 +107,15 @@ extern void analogReadResolution(int res);
  */
 extern void analogWriteResolution(uint8_t res);
 
+/*
+ * \brief Set the ADC sample time. Default is 3us (appropriate for low source resistance).
+ * See the chart of appropriate sample time vs. source resistance in the SAADC section
+ * of the Nordic nrf52 product specification.
+ *
+ * \param time Should be set to 3, 5, 10, 15, 20 or 40.
+ */
+extern void analogSampleTime(uint8_t sTime);
+
 extern void analogOutputInit( void ) ;
 
 #ifdef __cplusplus

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -19,10 +19,10 @@
 
 #if defined(NRF52) || defined(NRF52_SERIES)
 
-#include "nrf.h"
+#include <nrf.h>
 
-#include "Arduino.h"
-#include "wiring_private.h"
+#include <Arduino.h>
+#include <wiring_private.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,6 +30,7 @@ extern "C" {
 
 static uint32_t saadcReference = SAADC_CH_CONFIG_REFSEL_Internal;
 static uint32_t saadcGain      = SAADC_CH_CONFIG_GAIN_Gain1_6;
+static uint32_t saadcSampleTime = SAADC_CH_CONFIG_TACQ_3us;
 
 static bool saadcBurst = SAADC_CH_CONFIG_BURST_Disabled;
 
@@ -140,6 +141,28 @@ void analogOversampling( uint32_t ulOversampling )
 	}
 }
 
+void analogSampleTime( uint8_t sTime)
+{
+  saadcSampleTime = SAADC_CH_CONFIG_TACQ_3us; // default is 3 us
+  switch (sTime) {
+    case 5:
+      saadcSampleTime = SAADC_CH_CONFIG_TACQ_5us;
+      break;
+    case 10:
+      saadcSampleTime = SAADC_CH_CONFIG_TACQ_10us;
+      break;
+    case 15:
+      saadcSampleTime = SAADC_CH_CONFIG_TACQ_15us;
+      break;
+    case 20:
+      saadcSampleTime = SAADC_CH_CONFIG_TACQ_20us;
+      break;
+    case 40:
+      saadcSampleTime = SAADC_CH_CONFIG_TACQ_40us;
+      break;
+  }
+}
+
 static uint32_t analogRead_internal( uint32_t psel )
 {
   uint32_t saadcResolution;
@@ -171,7 +194,7 @@ static uint32_t analogRead_internal( uint32_t psel )
                             | ((SAADC_CH_CONFIG_RESP_Bypass   << SAADC_CH_CONFIG_RESN_Pos)   & SAADC_CH_CONFIG_RESN_Msk)
                             | ((saadcGain                     << SAADC_CH_CONFIG_GAIN_Pos)   & SAADC_CH_CONFIG_GAIN_Msk)
                             | ((saadcReference                << SAADC_CH_CONFIG_REFSEL_Pos) & SAADC_CH_CONFIG_REFSEL_Msk)
-                            | ((SAADC_CH_CONFIG_TACQ_3us      << SAADC_CH_CONFIG_TACQ_Pos)   & SAADC_CH_CONFIG_TACQ_Msk)
+                            | ((saadcSampleTime               << SAADC_CH_CONFIG_TACQ_Pos)   & SAADC_CH_CONFIG_TACQ_Msk)
                             | ((SAADC_CH_CONFIG_MODE_SE       << SAADC_CH_CONFIG_MODE_Pos)   & SAADC_CH_CONFIG_MODE_Msk)
                             | ((saadcBurst                    << SAADC_CH_CONFIG_BURST_Pos)   & SAADC_CH_CONFIG_BURST_Msk);
   NRF_SAADC->CH[0].PSELN = psel;


### PR DESCRIPTION
Provide the user with the ability to change the SAADC acquisition time to accommodate higher source resistance signals.