### PR TITLE
Add SAADC offset calibration and reading of CPU temperature

### DIFF
--- a/cores/nRF5/wiring.c
+++ b/cores/nRF5/wiring.c
@@ -145,7 +145,7 @@ void systemOff(uint32_t pin, uint8_t wake_logic)
 }
 
 
-float readCPUTemperature()
+float readCPUTemperature( void )
 {
   uint8_t en;
   int32_t temp;

--- a/cores/nRF5/wiring.c
+++ b/cores/nRF5/wiring.c
@@ -143,3 +143,44 @@ void systemOff(uint32_t pin, uint8_t wake_logic)
     NRF_POWER->SYSTEMOFF = 1;
   }
 }
+
+
+float readCPUTemperature()
+{
+  // These are defined simply to make the ensuing code easier to read. Ready and triggers are 0x01, and not ready is 0x00. 
+  // Many other library functions use a literal 0x00 to reset flags and a literal 0x01 for triggers, and test "done"
+  // flags for nonzero.  In this function, we used the defined constants. Using 0x00 and 0x01 would probably be fine
+  // because they're unlikely to ever change.
+  const uint32_t temp_ready = ( (TEMP_EVENTS_DATARDY_EVENTS_DATARDY_Generated << TEMP_EVENTS_DATARDY_EVENTS_DATARDY_Pos)
+                                && TEMP_EVENTS_DATARDY_EVENTS_DATARDY_Msk );
+
+  const uint32_t temp_not_ready = ( (TEMP_EVENTS_DATARDY_EVENTS_DATARDY_NotGenerated << TEMP_EVENTS_DATARDY_EVENTS_DATARDY_Pos)
+                                    && TEMP_EVENTS_DATARDY_EVENTS_DATARDY_Msk );
+
+  const uint32_t temp_trigger = ( (TEMP_TASKS_START_TASKS_START_Trigger << TEMP_TASKS_STOP_TASKS_STOP_Pos)
+                                  && TEMP_TASKS_START_TASKS_START_Msk );
+
+  const uint32_t temp_stop = ( (TEMP_TASKS_STOP_TASKS_STOP_Trigger << TEMP_TASKS_STOP_TASKS_STOP_Pos)
+                                  && TEMP_TASKS_STOP_TASKS_STOP_Msk );
+
+  uint8_t en;
+  int32_t temp;
+  (void) sd_softdevice_is_enabled(&en);
+  if (en) 
+  {
+    sd_temp_get(&temp);
+  }
+  else
+  {
+    NRF_TEMP->EVENTS_DATARDY = temp_not_ready; // Only needed in case another function is also looking at this event flag
+    NRF_TEMP->TASKS_START = temp_trigger; 
+  
+    bool done = false;
+    while (NRF_TEMP->EVENTS_DATARDY != temp_ready);
+    temp = NRF_TEMP->TEMP;                      // Per anomaly 29 (unclear whether still applicable), TASKS_STOP will clear the TEMP register.
+
+    NRF_TEMP->TASKS_STOP = temp_stop;           // Per anomaly 30 (unclear whether still applicable), the temp peripheral needs to be shut down
+    NRF_TEMP->EVENTS_DATARDY = temp_not_ready;
+  }
+  return temp / 4.0F;
+}

--- a/cores/nRF5/wiring.h
+++ b/cores/nRF5/wiring.h
@@ -46,7 +46,7 @@ static inline bool isInISR(void)
  * \brief Reads the on-chip temperature sensor, returning the temperature in degrees C
  * with a resolution of 0.25 degrees.
 */
-float readCPUTemperature();
+float readCPUTemperature( void );
 
 #ifdef __cplusplus
 }

--- a/cores/nRF5/wiring.h
+++ b/cores/nRF5/wiring.h
@@ -42,6 +42,12 @@ static inline bool isInISR(void)
   return (SCB->ICSR & SCB_ICSR_VECTACTIVE_Msk) != 0 ;
 }
 
+/*
+ * \brief Reads the on-chip temperature sensor, returning the temperature in degrees C
+ * with a resolution of 0.25 degrees.
+*/
+float readCPUTemperature();
+
 #ifdef __cplusplus
 }
 #endif

--- a/cores/nRF5/wiring_analog.h
+++ b/cores/nRF5/wiring_analog.h
@@ -116,6 +116,14 @@ extern void analogWriteResolution(uint8_t res);
  */
 extern void analogSampleTime(uint8_t sTime);
 
+/*
+ * \brief Calibrate the ADC offset. This is recommended occasionally, or any time the
+ * chip temperature changes by more than 10 C.  See the SAADC section of the Nordic
+ * nrf52 product pecification.
+ * 
+ */
+extern void analogCalibrateOffset();
+
 extern void analogOutputInit( void ) ;
 
 #ifdef __cplusplus

--- a/cores/nRF5/wiring_analog.h
+++ b/cores/nRF5/wiring_analog.h
@@ -122,7 +122,7 @@ extern void analogSampleTime(uint8_t sTime);
  * nrf52 product pecification.
  * 
  */
-extern void analogCalibrateOffset();
+extern void analogCalibrateOffset( void );
 
 extern void analogOutputInit( void ) ;
 

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -284,7 +284,7 @@ uint32_t analogReadVDD( void )
   return analogRead_internal(SAADC_CH_PSELP_PSELP_VDD);
 }
 
-analogCalibrateOffset()
+void analogCalibrateOffset( void )
 {
   // Enable the SAADC
   NRF_SAADC->ENABLE = 0x01;

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -284,6 +284,45 @@ uint32_t analogReadVDD( void )
   return analogRead_internal(SAADC_CH_PSELP_PSELP_VDD);
 }
 
+analogCalibrateOffset()
+{
+  const uint32_t calibrate_done = ( (SAADC_EVENTS_CALIBRATEDONE_EVENTS_CALIBRATEDONE_Generated << 
+                                      SAADC_EVENTS_CALIBRATEDONE_EVENTS_CALIBRATEDONE_Pos )
+                                    && SAADC_EVENTS_CH_LIMITH_LIMITH_Msk );
+  
+  const uint32_t calibrate_not_done = ( (SAADC_EVENTS_CALIBRATEDONE_EVENTS_CALIBRATEDONE_NotGenerated << 
+                                          SAADC_EVENTS_CALIBRATEDONE_EVENTS_CALIBRATEDONE_Pos )
+                                        && SAADC_EVENTS_CH_LIMITH_LIMITH_Msk );
+  
+  const uint32_t saadc_enable = ( (SAADC_ENABLE_ENABLE_Enabled << SAADC_ENABLE_ENABLE_Pos)
+                                  && SAADC_ENABLE_ENABLE_Msk );
+
+  const uint32_t saadc_disable = ( (SAADC_ENABLE_ENABLE_Disabled << SAADC_ENABLE_ENABLE_Pos)
+                                   && SAADC_ENABLE_ENABLE_Msk );
+
+  const uint32_t calibrate_trigger = ( (SAADC_TASKS_CALIBRATEOFFSET_TASKS_CALIBRATEOFFSET_Trigger <<
+                                         SAADC_TASKS_CALIBRATEOFFSET_TASKS_CALIBRATEOFFSET_Pos) 
+                                       && SAADC_TASKS_CALIBRATEOFFSET_TASKS_CALIBRATEOFFSET_Msk );
+
+  // Enable the SAADC
+  NRF_SAADC->ENABLE = saadc_enable;
+
+  // Be sure the done flag is cleared, then trigger offset calibration
+  NRF_SAADC->EVENTS_CALIBRATEDONE = calibrate_not_done;
+  NRF_SAADC->TASKS_CALIBRATEOFFSET = calibrate_trigger;
+
+  // Wait for completion
+  while (NRF_SAADC->EVENTS_CALIBRATEDONE != calibrate_done);
+  //bool done = false;
+  //for (int i = 0; (i < 20) && !(done = (NRF_SAADC->EVENTS_CALIBRATEDONE == calibrate_done)); i++ ) delay(1);
+
+  // Clear the done flag  (really shouldn't have to do this both times)
+  NRF_SAADC->EVENTS_CALIBRATEDONE = calibrate_not_done;
+
+  // Disable the SAADC
+  NRF_SAADC->ENABLE = saadc_disable;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -286,41 +286,21 @@ uint32_t analogReadVDD( void )
 
 analogCalibrateOffset()
 {
-  const uint32_t calibrate_done = ( (SAADC_EVENTS_CALIBRATEDONE_EVENTS_CALIBRATEDONE_Generated << 
-                                      SAADC_EVENTS_CALIBRATEDONE_EVENTS_CALIBRATEDONE_Pos )
-                                    && SAADC_EVENTS_CH_LIMITH_LIMITH_Msk );
-  
-  const uint32_t calibrate_not_done = ( (SAADC_EVENTS_CALIBRATEDONE_EVENTS_CALIBRATEDONE_NotGenerated << 
-                                          SAADC_EVENTS_CALIBRATEDONE_EVENTS_CALIBRATEDONE_Pos )
-                                        && SAADC_EVENTS_CH_LIMITH_LIMITH_Msk );
-  
-  const uint32_t saadc_enable = ( (SAADC_ENABLE_ENABLE_Enabled << SAADC_ENABLE_ENABLE_Pos)
-                                  && SAADC_ENABLE_ENABLE_Msk );
-
-  const uint32_t saadc_disable = ( (SAADC_ENABLE_ENABLE_Disabled << SAADC_ENABLE_ENABLE_Pos)
-                                   && SAADC_ENABLE_ENABLE_Msk );
-
-  const uint32_t calibrate_trigger = ( (SAADC_TASKS_CALIBRATEOFFSET_TASKS_CALIBRATEOFFSET_Trigger <<
-                                         SAADC_TASKS_CALIBRATEOFFSET_TASKS_CALIBRATEOFFSET_Pos) 
-                                       && SAADC_TASKS_CALIBRATEOFFSET_TASKS_CALIBRATEOFFSET_Msk );
-
   // Enable the SAADC
-  NRF_SAADC->ENABLE = saadc_enable;
+  NRF_SAADC->ENABLE = 0x01;
 
   // Be sure the done flag is cleared, then trigger offset calibration
-  NRF_SAADC->EVENTS_CALIBRATEDONE = calibrate_not_done;
-  NRF_SAADC->TASKS_CALIBRATEOFFSET = calibrate_trigger;
+  NRF_SAADC->EVENTS_CALIBRATEDONE = 0x00;
+  NRF_SAADC->TASKS_CALIBRATEOFFSET = 0x01;
 
   // Wait for completion
-  while (NRF_SAADC->EVENTS_CALIBRATEDONE != calibrate_done);
-  //bool done = false;
-  //for (int i = 0; (i < 20) && !(done = (NRF_SAADC->EVENTS_CALIBRATEDONE == calibrate_done)); i++ ) delay(1);
+  while (!NRF_SAADC->EVENTS_CALIBRATEDONE);
 
   // Clear the done flag  (really shouldn't have to do this both times)
-  NRF_SAADC->EVENTS_CALIBRATEDONE = calibrate_not_done;
+  NRF_SAADC->EVENTS_CALIBRATEDONE = 0x00;
 
   // Disable the SAADC
-  NRF_SAADC->ENABLE = saadc_disable;
+  NRF_SAADC->ENABLE = 0x00;
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
These additions

- add SAADC offset calibration to the analog library. Nordic recommends calibration if the system temperature is expected to change by more than 10 degrees C.
- add the ability to read the CPU (chip) temperature.

Notes:
- readCPUTemperature() returns a floating point value. Internally, the TEMP peripheral provides an integer with 1 LSB = 0.25 degrees C. Repeatability is +/- 0.25 C but accuracy is only +/- 5 C.  The floating point value is a convenience for the novice user. If just passing along the integer is preferred, I can change it.
- Though initiating offset calibration is probably the main reason for checking the temperature, readCPUTemperature() was added to wiring.c/h rather than to wiring_analog_. I'd be happy to move it if another location is preferred. I didn't see any more logical place, and it didn't seem worthwhile to create any new files.
- Though existing header files include #defined values for flag and trigger fields, both functions used hard-coded constants of 0x00 for not ready or disable, nonzero for ready, and 0x01 for triggers. This follows the existing pattern as well as many Nordic examples, so it is likely to be reasonably future-proof.
- I left in a few comments that perhaps should be removed.