### PR TITLE
add menu debug out option to select output meessage channel

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1,5 +1,6 @@
 menu.softdevice=SoftDevice
 menu.debug=Debug
+menu.debug_output=Debug Output
 
 # -----------------------------------
 # Adafruit Feather nRF52832
@@ -45,6 +46,14 @@ feather52832.menu.debug.l2.build.debug_flags=-DCFG_DEBUG=2
 feather52832.menu.debug.l3=Level 3 (Segger SystemView)
 feather52832.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 feather52832.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
+
+# Debug Output Menu
+feather52832.menu.debug_output.serial=Serial
+feather52832.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+feather52832.menu.debug_output.serial1=Serial1
+feather52832.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+feather52832.menu.debug_output.rtt=Segger RTT
+feather52832.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
 
 # -----------------------------------
 # Adafruit Feather nRF52840 Express
@@ -100,6 +109,14 @@ feather52840.menu.debug.l3=Level 3 (Segger SystemView)
 feather52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 feather52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
+# Debug Output Menu
+feather52840.menu.debug_output.serial=Serial
+feather52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+feather52840.menu.debug_output.serial1=Serial1
+feather52840.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+feather52840.menu.debug_output.rtt=Segger RTT
+feather52840.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+
 # -----------------------------------
 # Adafruit Feather nRF52840 Sense
 # -----------------------------------
@@ -153,6 +170,14 @@ feather52840sense.menu.debug.l2.build.debug_flags=-DCFG_DEBUG=2
 feather52840sense.menu.debug.l3=Level 3 (Segger SystemView)
 feather52840sense.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 feather52840sense.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
+
+# Debug Output Menu
+feather52840sense.menu.debug_output.serial=Serial
+feather52840sense.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+feather52840sense.menu.debug_output.serial1=Serial1
+feather52840sense.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+feather52840sense.menu.debug_output.rtt=Segger RTT
+feather52840sense.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
 
 # -----------------------------------
 # Adafruit ItsyBitsy nRF52840 Express
@@ -208,6 +233,14 @@ itsybitsy52840.menu.debug.l3=Level 3 (Segger SystemView)
 itsybitsy52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 itsybitsy52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
+# Debug Output Menu
+itsybitsy52840.menu.debug_output.serial=Serial
+itsybitsy52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+itsybitsy52840.menu.debug_output.serial1=Serial1
+itsybitsy52840.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+itsybitsy52840.menu.debug_output.rtt=Segger RTT
+itsybitsy52840.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+
 # -----------------------------------
 # Adafruit Circuit Playground Bluefruit
 # -----------------------------------
@@ -259,6 +292,14 @@ cplaynrf52840.menu.debug.l2.build.debug_flags=-DCFG_DEBUG=2
 cplaynrf52840.menu.debug.l3=Level 3 (Segger SystemView)
 cplaynrf52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 cplaynrf52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
+
+# Debug Output Menu
+cplaynrf52840.menu.debug_output.serial=Serial
+cplaynrf52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+cplaynrf52840.menu.debug_output.serial1=Serial1
+cplaynrf52840.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+cplaynrf52840.menu.debug_output.rtt=Segger RTT
+cplaynrf52840.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
 
 # -----------------------------------
 # Adafruit CLUE
@@ -312,6 +353,14 @@ cluenrf52840.menu.debug.l3=Level 3 (Segger SystemView)
 cluenrf52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 cluenrf52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
+# Debug Output Menu
+cluenrf52840.menu.debug_output.serial=Serial
+cluenrf52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+cluenrf52840.menu.debug_output.serial1=Serial1
+cluenrf52840.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+cluenrf52840.menu.debug_output.rtt=Segger RTT
+cluenrf52840.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+
 # -----------------------------------
 # Adafruit LED Glasses Driver nRF52840
 # -----------------------------------
@@ -364,6 +413,14 @@ ledglasses_nrf52840.menu.debug.l3=Level 3 (Segger SystemView)
 ledglasses_nrf52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 ledglasses_nrf52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
+# Debug Output Menu
+ledglasses_nrf52840.menu.debug_output.serial=Serial
+ledglasses_nrf52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+ledglasses_nrf52840.menu.debug_output.serial1=Serial1
+ledglasses_nrf52840.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+ledglasses_nrf52840.menu.debug_output.rtt=Segger RTT
+ledglasses_nrf52840.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+
 # -----------------------------------
 # Raytac nRF52840 Dongle
 # -----------------------------------
@@ -415,6 +472,14 @@ mdbt50qrx.menu.debug.l2.build.debug_flags=-DCFG_DEBUG=2
 mdbt50qrx.menu.debug.l3=Level 3 (Segger SystemView)
 mdbt50qrx.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 mdbt50qrx.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
+
+# Debug Output Menu
+mdbt50qrx.menu.debug_output.serial=Serial
+mdbt50qrx.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+mdbt50qrx.menu.debug_output.serial1=Serial1
+mdbt50qrx.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+mdbt50qrx.menu.debug_output.rtt=Segger RTT
+mdbt50qrx.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
 
 # -----------------------------------
 # Adafruit Metro nRF52840 Express
@@ -469,6 +534,14 @@ metro52840.menu.debug.l2.build.debug_flags=-DCFG_DEBUG=2
 metro52840.menu.debug.l3=Level 3 (Segger SystemView)
 metro52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 metro52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
+
+# Debug Output Menu
+metro52840.menu.debug_output.serial=Serial
+metro52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+metro52840.menu.debug_output.serial1=Serial1
+metro52840.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+metro52840.menu.debug_output.rtt=Segger RTT
+metro52840.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
 
 
 # -------------------------------------------------------
@@ -527,6 +600,14 @@ pca10056.menu.debug.l3=Level 3 (Segger SystemView)
 pca10056.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 pca10056.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
+# Debug Output Menu
+pca10056.menu.debug_output.serial=Serial
+pca10056.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+pca10056.menu.debug_output.serial1=Serial1
+pca10056.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+pca10056.menu.debug_output.rtt=Segger RTT
+pca10056.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL
+
 # -----------------------------------
 # Particle Xenon
 # -----------------------------------
@@ -576,3 +657,11 @@ particle_xenon.menu.debug.l2.build.debug_flags=-DCFG_DEBUG=2
 particle_xenon.menu.debug.l3=Level 3 (Segger SystemView)
 particle_xenon.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 particle_xenon.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
+
+# Debug Output Menu
+particle_xenon.menu.debug_output.serial=Serial
+particle_xenon.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
+particle_xenon.menu.debug_output.serial1=Serial1
+particle_xenon.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG
+particle_xenon.menu.debug_output.rtt=Segger RTT
+particle_xenon.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL

--- a/cores/nRF5/common_func.h
+++ b/cores/nRF5/common_func.h
@@ -176,12 +176,12 @@ const char* dbg_err_str(int32_t err_id); // TODO move to other place
 
 #if CFG_DEBUG
 
-#define PRINT_LOCATION()      PRINTF("%s: %d:\n", __PRETTY_FUNCTION__, __LINE__)
-#define PRINT_MESS(x)         PRINTF("%s: %d: %s \n"   , __FUNCTION__, __LINE__, (char*)(x))
-#define PRINT_HEAP()          if (CFG_DEBUG >= 3) PRINTF("\n%s: %d: Heap free: %d\n", __FUNCTION__, __LINE__, util_heap_get_free_size())
-#define PRINT_STR(x)          PRINTF("%s: %d: " #x " = %s\n"   , __FUNCTION__, __LINE__, (char*)(x) )
-#define PRINT_INT(x)          PRINTF("%s: %d: " #x " = %ld\n"  , __FUNCTION__, __LINE__, (uint32_t) (x) )
-#define PRINT_FLOAT(x)        PRINTF("%s: %d: " #x " = %f\n"  , __FUNCTION__, __LINE__, (float) (x) )
+#define PRINT_LOCATION()      PRINTF("%s: %d:\r\n", __PRETTY_FUNCTION__, __LINE__)
+#define PRINT_MESS(x)         PRINTF("%s: %d: %s \r\n"   , __FUNCTION__, __LINE__, (char*)(x))
+#define PRINT_HEAP()          if (CFG_DEBUG >= 3) PRINTF("\n%s: %d: Heap free: %d\r\n", __FUNCTION__, __LINE__, util_heap_get_free_size())
+#define PRINT_STR(x)          PRINTF("%s: %d: " #x " = %s\r\n"   , __FUNCTION__, __LINE__, (char*)(x) )
+#define PRINT_INT(x)          PRINTF("%s: %d: " #x " = %ld\r\n"  , __FUNCTION__, __LINE__, (uint32_t) (x) )
+#define PRINT_FLOAT(x)        PRINTF("%s: %d: " #x " = %f\r\n"  , __FUNCTION__, __LINE__, (float) (x) )
 
 #define PRINT_HEX(x) \
   do {\
@@ -196,7 +196,7 @@ const char* dbg_err_str(int32_t err_id); // TODO move to other place
     uint8_t const* p8 = (uint8_t const*) (buf);\
     PRINTF(#buf ": ");\
     for(uint32_t i=0; i<(n); i++) {\
-      if (i%16 == 0) PRINTF("\n"); \
+      if (i%16 == 0) PRINTF("\r\n"); \
       PRINTF("%02x ", p8[i]); \
     }\
     PRINTF("\r\n");\
@@ -212,7 +212,7 @@ const char* dbg_err_str(int32_t err_id); // TODO move to other place
 #define ADALOG_BUFFER(_tag, _buf, _n) \
   do {\
     const char * _xtag = _tag;\
-    if ( _xtag ) PRINTF("%-6s: len = %d\n", _xtag, _n);\
+    if ( _xtag ) PRINTF("%-6s: len = %d\r\n", _xtag, _n);\
     dbgDumpMemory(_buf, 1, _n, true);\
   }while(0)
 

--- a/platform.txt
+++ b/platform.txt
@@ -53,9 +53,10 @@ compiler.ldflags=-mcpu={build.mcu} -mthumb {build.float_flags} -Wl,--cref -Wl,--
 compiler.size.cmd=arm-none-eabi-size
 
 # this can be overriden in boards.txt
+# Logger 0: Serial (CDC), 1 Serial1 (UART), 2 Segger RTT
 build.float_flags=-mfloat-abi=hard -mfpu=fpv4-sp-d16 -u _printf_float
 build.debug_flags=-DCFG_DEBUG=0
-build.logger_flags=-DCFG_LOGGER=1
+build.logger_flags=-DCFG_LOGGER=0
 build.sysview_flags=-DCFG_SYSVIEW=0
 
 # USB flags
@@ -78,8 +79,6 @@ compiler.arm.cmsis.ldflags="-L{runtime.tools.CMSIS-5.7.0.path}/CMSIS/DSP/Lib/GCC
 rtos.path={build.core.path}/freertos
 nordic.path={build.core.path}/nordic
 
-# build.logger_flags and build.sysview_flags are intentionally empty,
-# to allow modification via a user's own boards.local.txt or platform.local.txt files.
 build.flags.nrf= -DSOFTDEVICE_PRESENT -DARDUINO_NRF52_ADAFRUIT -DNRF52_SERIES -DDX_CC_TEE -DLFS_NAME_MAX=64 {compiler.optimization_flag} {build.debug_flags} {build.logger_flags} {build.sysview_flags} {compiler.arm.cmsis.c.flags} "-I{nordic.path}" "-I{nordic.path}/nrfx" "-I{nordic.path}/nrfx/hal" "-I{nordic.path}/nrfx/mdk" "-I{nordic.path}/nrfx/soc" "-I{nordic.path}/nrfx/drivers/include" "-I{nordic.path}/nrfx/drivers/src" "-I{nordic.path}/softdevice/{build.sd_name}_nrf52_{build.sd_version}_API/include" "-I{nordic.path}/softdevice/{build.sd_name}_nrf52_{build.sd_version}_API/include/nrf52" "-I{rtos.path}/Source/include" "-I{rtos.path}/config" "-I{rtos.path}/portable/GCC/nrf52" "-I{rtos.path}/portable/CMSIS/nrf52" "-I{build.core.path}/sysview/SEGGER" "-I{build.core.path}/sysview/Config" "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 
 # Compile patterns

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from bokeh.palettes import name
 
 mcu_dict = {
     52832: {
@@ -102,17 +103,27 @@ def build_debug(name):
     print("%s.menu.debug.l3=Level 3 (Segger SystemView)" % name)
     print("%s.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3" % name)
     print("%s.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1" % name)
+    print()
 
+def build_debug_output(name):
+    print("# Debug Output Menu")
+    print("%s.menu.debug_output.serial=Serial" % name)
+    print("%s.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0" % name)
+    print("%s.menu.debug_output.serial1=Serial1" % name)
+    print("%s.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG" % name)
+    print("%s.menu.debug_output.rtt=Segger RTT" % name)
+    print("%s.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL" % name)
 
 def build_global_menu():
     print("menu.softdevice=SoftDevice")
     print("menu.debug=Debug")
-
+    print("menu.debug_output=Debug Output")
 
 def make_board(name, vendor_name, product_name, vid, pid, boarddefine, variant):
     build_header(name, vendor_name, product_name, vid, pid, boarddefine, variant)
     build_softdevice(name)
     build_debug(name)
+    build_debug_output(name)
 
 
 build_global_menu()


### PR DESCRIPTION
- Add debug output menu to select log output channel to Serial (CDC), Seria1 (HWUART) or or Segger RTT
- fix #416 

![Screenshot from 2021-11-24 14-16-55](https://user-images.githubusercontent.com/249515/143192413-0efbb538-ed0e-49f9-bf0e-3743c315b16c.png)
