### PR TITLE
clear STOPPED event when start transmission,

### DIFF
--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -51,13 +51,13 @@ void TwoWire::begin(void) {
   //Main Mode
   master = true;
 
-  *pincfg_reg(_uc_pinSCL) = ((uint32_t)GPIO_PIN_CNF_DIR_Input        << GPIO_PIN_CNF_DIR_Pos)
+  *pincfg_reg(_uc_pinSCL) = ((uint32_t)GPIO_PIN_CNF_DIR_Input         << GPIO_PIN_CNF_DIR_Pos)
                            | ((uint32_t)GPIO_PIN_CNF_INPUT_Connect    << GPIO_PIN_CNF_INPUT_Pos)
                            | ((uint32_t)GPIO_PIN_CNF_PULL_Pullup      << GPIO_PIN_CNF_PULL_Pos)
                            | ((uint32_t)GPIO_PIN_CNF_DRIVE_S0D1       << GPIO_PIN_CNF_DRIVE_Pos)
                            | ((uint32_t)GPIO_PIN_CNF_SENSE_Disabled   << GPIO_PIN_CNF_SENSE_Pos);
 
-  *pincfg_reg(_uc_pinSDA) = ((uint32_t)GPIO_PIN_CNF_DIR_Input        << GPIO_PIN_CNF_DIR_Pos)
+  *pincfg_reg(_uc_pinSDA) = ((uint32_t)GPIO_PIN_CNF_DIR_Input         << GPIO_PIN_CNF_DIR_Pos)
                            | ((uint32_t)GPIO_PIN_CNF_INPUT_Connect    << GPIO_PIN_CNF_INPUT_Pos)
                            | ((uint32_t)GPIO_PIN_CNF_PULL_Pullup      << GPIO_PIN_CNF_PULL_Pos)
                            | ((uint32_t)GPIO_PIN_CNF_DRIVE_S0D1       << GPIO_PIN_CNF_DRIVE_Pos)
@@ -218,6 +218,8 @@ uint8_t TwoWire::endTransmission(bool stopBit)
   // Start I2C transmission
   _p_twim->ADDRESS = txAddress;
 
+  // just in case twi is stopped by bus error such as secondary device reset/stalled without replying ACK/NACK
+  _p_twim->EVENTS_STOPPED = 0x0UL;
   _p_twim->TASKS_RESUME = 0x1UL;
 
   _p_twim->TXD.PTR = (uint32_t)txBuffer._aucBuffer;


### PR DESCRIPTION
clear STOPPED event when start transmission,  which could be caused by… missing ack from previous transaction. Part of effort to resolve
- https://github.com/adafruit/Adafruit_LTR390/issues/2