### PR TITLE
support longer ms values in ms2tick

### DIFF
--- a/cores/nRF5/freertos/Source/include/projdefs.h
+++ b/cores/nRF5/freertos/Source/include/projdefs.h
@@ -38,7 +38,7 @@ typedef void (*TaskFunction_t)( void * );
 overridden by a macro of the same name defined in FreeRTOSConfig.h in case the
 definition here is not suitable for your application. */
 #ifndef pdMS_TO_TICKS
-	#define pdMS_TO_TICKS( xTimeInMs ) ( ( TickType_t ) ( ( ( TickType_t ) ( xTimeInMs ) * ( TickType_t ) configTICK_RATE_HZ ) / ( TickType_t ) 1000 ) )
+	#define pdMS_TO_TICKS( xTimeInMs ) ( ( TickType_t ) ( ( ( TickType_t ) ( xTimeInMs ) * ( uint64_t ) configTICK_RATE_HZ ) / ( TickType_t ) 1000 ) )
 #endif
 
 #define pdFALSE			( ( BaseType_t ) 0 )


### PR DESCRIPTION
Use uint64_t for intermediate calculate of pdMS_TO_TICKS so stop integer overflow for long ms values. Fixes #705