### PR TITLE
fix issue with blitFrameBuffer not working on Adafruit CLUE (HT @jimsbugs)

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -207,8 +207,13 @@ void SPIClass::transfer(const void *tx_buf, void *rx_buf, size_t count)
 
   while (count)
   {
+#ifdef _VARIANT_CLUE52840_
+    // each transfer can only up to 64KB (16-bit) bytes
+    const size_t xfer_len = min(count, UINT16_MAX);
+#else
     // each transfer can only up to 64KB (16-bit) bytes
     const size_t xfer_len = min((uint16_t) count, UINT16_MAX);
+#endif
 
     nrfx_spim_xfer_desc_t xfer_desc =
     {

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -207,13 +207,8 @@ void SPIClass::transfer(const void *tx_buf, void *rx_buf, size_t count)
 
   while (count)
   {
-#ifdef _VARIANT_CLUE52840_
     // each transfer can only up to 64KB (16-bit) bytes
     const size_t xfer_len = min(count, UINT16_MAX);
-#else
-    // each transfer can only up to 64KB (16-bit) bytes
-    const size_t xfer_len = min((uint16_t) count, UINT16_MAX);
-#endif
 
     nrfx_spim_xfer_desc_t xfer_desc =
     {


### PR DESCRIPTION
Fixes an issue identified here https://forums.adafruit.com/viewtopic.php?f=65&t=185669 where blitFrameBuffer hangs on Adafruit CLUE