### PR TITLE
Fixed small spelling mistake in central_bleuart.ino sketch

### DIFF
--- a/libraries/Bluefruit52Lib/examples/Central/central_bleuart/central_bleuart.ino
+++ b/libraries/Bluefruit52Lib/examples/Central/central_bleuart/central_bleuart.ino
@@ -36,7 +36,7 @@ void setup()
   
   Bluefruit.setName("Bluefruit52 Central");
 
-  // Configure Battyer client
+  // Configure Battery client
   clientBas.begin();  
 
   // Configure DIS client


### PR DESCRIPTION
Found a small spelling mistake in the sketch while having a read through. Couldn't help but update it.