### PR TITLE
add -Werror=return-type for all warning options

### DIFF
--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -208,7 +208,7 @@ void SPIClass::transfer(const void *tx_buf, void *rx_buf, size_t count)
   while (count)
   {
     // each transfer can only up to 64KB (16-bit) bytes
-    const size_t xfer_len = min(count, UINT16_MAX);
+    const size_t xfer_len = min(count, (size_t) UINT16_MAX);
 
     nrfx_spim_xfer_desc_t xfer_desc =
     {

--- a/platform.txt
+++ b/platform.txt
@@ -22,11 +22,11 @@ version=1.2.0
 # Compile variables
 # -----------------
 
-compiler.warning_flags=-w
-compiler.warning_flags.none=-w
-compiler.warning_flags.default=
-compiler.warning_flags.more=-Wall
-compiler.warning_flags.all=-Wall -Wextra -Wno-unused-parameter -Wno-missing-field-initializers -Wno-pointer-arith
+compiler.warning_flags=-Werror=return-type
+compiler.warning_flags.none=-Werror=return-type
+compiler.warning_flags.default=-Werror=return-type
+compiler.warning_flags.more=-Wall -Werror=return-type
+compiler.warning_flags.all=-Wall -Wextra -Werror=return-type -Wno-unused-parameter -Wno-missing-field-initializers -Wno-pointer-arith
 
 # Allow changing optimization settings via platform.local.txt / boards.local.txt
 compiler.optimization_flag=-Ofast


### PR DESCRIPTION
Fix dangerous issue where the function declared with return value does not return at all. Which could cause mis-matched issue on the execution stack. Force this as an error for all compiler warning option. See also https://forums.adafruit.com/viewtopic.php?f=62&t=186839 