### PR TITLE
HID Gamepad Client & Central HID Gamepad example

### DIFF
--- a/libraries/Bluefruit52Lib/examples/Central/central_hid/central_hid.ino
+++ b/libraries/Bluefruit52Lib/examples/Central/central_hid/central_hid.ino
@@ -18,21 +18,33 @@
  */
 #include <bluefruit.h>
 
-// Polling or callback implementation
-#define POLLING       1
+/*
+ * Polling or callback implementation
+ * 0 = Request data using a poll
+ * 1 = Use callbacks 
+ */
+#define POLLING           0
+/*
+ * Device Type flag for use in the example
+ * Change this if you want to demo the Gamepad!
+ * 0 = Keyboard + Mouse
+ * 1 = Gamepad
+ */
+#define DEVICE_TYPE       0
 
 BLEClientHidAdafruit hid;
 
 // Last checked report, to detect if there is changes between reports
 hid_keyboard_report_t last_kbd_report = { 0 };
 hid_mouse_report_t last_mse_report = { 0 };
+hid_gamepad_report_t last_gpd_report = { 0 };
 
 void setup()
 {
   Serial.begin(115200);
 //  while ( !Serial ) delay(10);   // for nrf52840 with native usb
 
-  Serial.println("Bluefruit52 Central HID (Keyboard + Mouse) Example");
+  Serial.println("Bluefruit52 Central HID (Keyboard + Mouse + Gamepad) Example");
   Serial.println("--------------------------------------------------\n");
   
   // Initialize Bluefruit with maximum connections as Peripheral = 0, Central = 1
@@ -46,6 +58,7 @@ void setup()
 
   #if POLLING == 0  
   hid.setKeyboardReportCallback(keyboard_report_callback);
+  hid.setGamepadReportCallback(gamepad_report_callback);
   #endif
 
   // Increase Blink rate to different from PrPh advertising mode
@@ -69,7 +82,7 @@ void setup()
   Bluefruit.Scanner.restartOnDisconnect(true);
   Bluefruit.Scanner.setInterval(160, 80); // in unit of 0.625 ms
   Bluefruit.Scanner.filterService(hid);   // only report HID service
-  Bluefruit.Scanner.useActiveScan(false);
+  Bluefruit.Scanner.useActiveScan(true);
   Bluefruit.Scanner.start(0);             // 0 = Don't stop scanning after n seconds
 }
 
@@ -137,14 +150,20 @@ void connection_secured_callback(uint16_t conn_handle)
     Serial.printf("HID Flags  : 0x%02X\n", hidInfo[3]);
 
     // BLEClientHidAdafruit currently only supports Boot Protocol Mode
-    // for Keyboard and Mouse. Let's set the protocol mode on prph to Boot Mode
+    // for Keyboard and Mouse. If we are using a Keyboard + Mouse,
+    // let's set the protocol mode on prph to Boot Mode.
+#if DEVICE_TYPE == 0
     hid.setBootMode(true);
+#endif
 
     // Enable Keyboard report notification if present on prph
     if ( hid.keyboardPresent() ) hid.enableKeyboard();
 
     // Enable Mouse report notification if present on prph
     if ( hid.mousePresent() ) hid.enableMouse();
+
+    // Enable Gamepad report notification if present on prph
+    if ( hid.gamepadPresent() ) hid.enableGamepad();
 
     Serial.println("Ready to receive from peripheral");
   }
@@ -169,15 +188,26 @@ void loop()
 #if POLLING == 1
   // nothing to do if hid not discovered
   if ( !hid.discovered() ) return;
+
+  if ( hid.keyboardPresent() ) {
+    /*------------- Polling Keyboard  -------------*/
+    hid_keyboard_report_t kbd_report;
   
-  /*------------- Polling Keyboard  -------------*/
-  hid_keyboard_report_t kbd_report;
+    // Get latest report
+    Serial.println("Get report from Keyboard");
+    hid.getKeyboardReport(&kbd_report);
+    processKeyboardReport(&kbd_report);
+  }
 
-  // Get latest report
-  hid.getKeyboardReport(&kbd_report);
-
-  processKeyboardReport(&kbd_report);
-
+  if ( hid.gamepadPresent() ) {
+    /*------------- Polling Gamepad  -------------*/
+    hid_gamepad_report_t gpd_report;
+  
+    // Get latest report
+    Serial.println("Get report from Gamepad");
+    hid.getGamepadReport(&gpd_report);
+    processGamepadReport(&gpd_report);
+  }
 
   // polling interval is 5 ms
   delay(5);
@@ -185,6 +215,24 @@ void loop()
   
 }
 
+
+void gamepad_report_callback(hid_gamepad_report_t* report)
+{
+  Serial.println("Recieved report from Gamepad");
+  processGamepadReport(report);
+}
+
+void processGamepadReport(hid_gamepad_report_t* report)
+{
+  memcpy(&last_gpd_report, report, sizeof(hid_gamepad_report_t));  
+  
+  Serial.print("Current Gamepad State: Buttons: ");
+  Serial.print(report->buttons, BIN);
+  Serial.print(" X: ");
+  Serial.print(report->x);
+  Serial.print(" Y: ");
+  Serial.println(report->y);
+}
 
 void keyboard_report_callback(hid_keyboard_report_t* report)
 {

--- a/libraries/Bluefruit52Lib/src/BLEDiscovery.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEDiscovery.cpp
@@ -240,6 +240,10 @@ void BLEDiscovery::_eventHandler(ble_evt_t* evt)
 
       LOG_LV2("DISC", "[CHR] Characteristic Count: %d", chr_rsp->count);
 
+      for (uint8_t i; i < chr_rsp->count; i++) {
+        LOG_LV2("DISC", "[CHR] Characteristic #%d: 0x%04X", i, chr_rsp->chars[i].uuid.uuid);
+      }
+
       if (gattc->gatt_status == BLE_GATT_STATUS_SUCCESS)
       {
         if ( chr_rsp->count )

--- a/libraries/Bluefruit52Lib/src/BLEDiscovery.h
+++ b/libraries/Bluefruit52Lib/src/BLEDiscovery.h
@@ -101,6 +101,18 @@ class BLEDiscovery
       return discoverCharacteristic(conn_handle, chr_arr, arrcount(chr_arr));
     }
 
+    uint8_t  discoverCharacteristic(uint16_t conn_handle, BLEClientCharacteristic& chr1, BLEClientCharacteristic& chr2, BLEClientCharacteristic& chr3, BLEClientCharacteristic& chr4, BLEClientCharacteristic& chr5, BLEClientCharacteristic& chr6, BLEClientCharacteristic& chr7)
+    {
+      BLEClientCharacteristic* chr_arr[] = {&chr1, &chr2, &chr3, &chr4, &chr5, &chr6, &chr7};
+      return discoverCharacteristic(conn_handle, chr_arr, arrcount(chr_arr));
+    }
+
+    uint8_t  discoverCharacteristic(uint16_t conn_handle, BLEClientCharacteristic& chr1, BLEClientCharacteristic& chr2, BLEClientCharacteristic& chr3, BLEClientCharacteristic& chr4, BLEClientCharacteristic& chr5, BLEClientCharacteristic& chr6, BLEClientCharacteristic& chr7, BLEClientCharacteristic& chr8)
+    {
+      BLEClientCharacteristic* chr_arr[] = {&chr1, &chr2, &chr3, &chr4, &chr5, &chr6, &chr7, &chr8};
+      return discoverCharacteristic(conn_handle, chr_arr, arrcount(chr_arr));
+    }
+
     /*------------------------------------------------------------------*/
     /* INTERNAL USAGE ONLY
      * Although declare as public, it is meant to be invoked by internal

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientHidAdafruit.cpp
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientHidAdafruit.cpp
@@ -120,23 +120,10 @@ bool BLEClientHidAdafruit::discover(uint16_t conn_handle)
   _conn_hdl = BLE_CONN_HANDLE_INVALID; // make as invalid until we found all chars
 
   // Discover all characteristics
-  Bluefruit.Discovery.discoverCharacteristic(conn_handle, _protcol_mode, _kbd_boot_input, _kbd_boot_output, _hid_info, _hid_control, _gpd_report);
+  Bluefruit.Discovery.discoverCharacteristic(conn_handle, _protcol_mode, _kbd_boot_input, _kbd_boot_output, _mse_boot_input, _hid_info, _hid_control, _gpd_report);
 
-  Serial.print("_protcol_mode.discovered(): ");
-  Serial.println(_protcol_mode.discovered());
-
-  Serial.print("_hid_info.discovered(): ");
-  Serial.println(_hid_info.discovered());
-
-  Serial.print("_hid_control.discovered(): ");
-  Serial.println(_hid_control.discovered());
-
-  Serial.print("_gpd_report.discovered(): ");
-  Serial.println(_gpd_report.discovered());
-
-
-  VERIFY( /*_protcol_mode.discovered() &&*/ _hid_info.discovered() && _hid_control.discovered() );
-  // VERIFY ( keyboardPresent() || mousePresent() || gamepadPresent() );
+  VERIFY( _hid_info.discovered() && _hid_control.discovered() );
+  VERIFY (keyboardPresent() || mousePresent() || gamepadPresent());
 
   _conn_hdl = conn_handle;
   return true;
@@ -169,7 +156,7 @@ bool BLEClientHidAdafruit::setBootMode(bool boot)
  *------------------------------------------------------------------*/
 bool BLEClientHidAdafruit::keyboardPresent(void)
 {
-  return _kbd_boot_input.discovered() && _kbd_boot_output.discovered();
+  return _kbd_boot_input.discovered() && _kbd_boot_output.discovered() && _protcol_mode.discovered();
 }
 
 bool BLEClientHidAdafruit::enableKeyboard(void)
@@ -200,7 +187,7 @@ void BLEClientHidAdafruit::getKeyboardReport(hid_keyboard_report_t* report)
  *------------------------------------------------------------------*/
 bool BLEClientHidAdafruit::mousePresent(void)
 {
-  return _mse_boot_input.discovered();
+  return _mse_boot_input.discovered() && _protcol_mode.discovered();
 }
 
 bool BLEClientHidAdafruit::enableMouse(void)

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientHidAdafruit.h
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientHidAdafruit.h
@@ -49,6 +49,7 @@ class BLEClientHidAdafruit : public BLEClientService
     // Callback Signatures
     typedef void (*kbd_callback_t ) (hid_keyboard_report_t* report);
     typedef void (*mse_callback_t ) (hid_mouse_report_t* report);
+    typedef void (*gpd_callback_t ) (hid_gamepad_report_t* report);
 
     BLEClientHidAdafruit(void);
 
@@ -74,16 +75,26 @@ class BLEClientHidAdafruit : public BLEClientService
 
     void getMouseReport(hid_mouse_report_t* report);
 
+    // Gamepad API
+    bool gamepadPresent(void);
+    bool enableGamepad(void);
+    bool disableGamepad(void);
+
+    void getGamepadReport(hid_gamepad_report_t* report);
+
     // Report callback
     void setKeyboardReportCallback(kbd_callback_t fp);
     void setMouseReportCallback(mse_callback_t fp);
+    void setGamepadReportCallback(gpd_callback_t fp);
 
   protected:
     kbd_callback_t _kbd_cb;
     mse_callback_t _mse_cb;
+    gpd_callback_t _gpd_cb;
 
     hid_keyboard_report_t _last_kbd_report;
     hid_mouse_report_t    _last_mse_report;
+    hid_gamepad_report_t  _last_gpd_report;
 
     // Only support Boot protocol for keyboard and Mouse
     BLEClientCharacteristic _protcol_mode;
@@ -95,11 +106,15 @@ class BLEClientHidAdafruit : public BLEClientService
 
     BLEClientCharacteristic _mse_boot_input;
 
+    BLEClientCharacteristic _gpd_report;
+
     void _handle_kbd_input(uint8_t* data, uint16_t len);
     void _handle_mse_input(uint8_t* data, uint16_t len);
+    void _handle_gpd_input(uint8_t* data, uint16_t len);
 
     friend void kbd_client_notify_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len);
     friend void mse_client_notify_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len);
+    friend void gpd_client_notify_cb(BLEClientCharacteristic* chr, uint8_t* data, uint16_t len);
 };
 
 


### PR DESCRIPTION
Hello! I have been working on a personal project recently and came across some missing functionality inside of the library. There was no way to connect as a Central role to an HID Gamepad peripheral. I went ahead and implemented it myself closely mirroring the Keyboard support.

This work is related to and extends upon the following old issues and pull requests.
- https://github.com/adafruit/Adafruit_nRF52_Arduino/issues/228
- https://github.com/adafruit/Adafruit_nRF52_Arduino/pull/622
- https://github.com/adafruit/Adafruit_nRF52_Arduino/pull/688

The testing process I took is as follows:
1. Upload the (newly updated) example at `examples/Central/central_hid/central_hid.ino` to an Adafruit Feather NRF52840 Express board
2. Upload the example at `examples/Peripheral/blehid_gamepad/blehid_gamepad.ino` to an Adafruit Feather NRF52840 Express board
3. View each's Serial Console to verify:
- They both fully pair to each other
- The Central feather is able to receive gamepad reports from the Periph feather
- Both polling and callback functionality works from the Central role

I am fairly confident it should be ready to be merged in, however I would greatly appreciate feedback on what to change.

# Changelog
## Added
- Example for connecting to BLE Gamepads from a Central role
- Support for HID Gamepad Clients in `BLEClientHidAdafruit`
## Changed
- Allow for up to **8 BLE Characteristics** inside of `BLEDiscovery` (This is likely something that will need discussion and feedback on it)
- Add Debug logging to log UUID of all BLE Characteristics for a service inside of `BLEDiscovery`