### PR TITLE
Fix wrongful inclusion of Adafruit nRFCrypto library

### DIFF
--- a/libraries/Bluefruit52Lib/library.json
+++ b/libraries/Bluefruit52Lib/library.json
@@ -1,0 +1,25 @@
+{
+  "name": "Adafruit Bluefruit nRF52 Libraries",
+  "version": "0.21.0",
+  "description": "Arduino library for nRF52-based Adafruit Bluefruit LE modules",
+  "keywords": "bluefruit, ble",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/adafruit/Adafruit_nRF52_Arduino/tree/master/libraries/Bluefruit52Lib"
+  },
+  "authors":
+  [
+    {
+      "name": "Adafruit",
+      "email": "info@adafruit.com",
+    }
+  ],
+  "license": "BSD-3",
+  "frameworks": "arduino",
+  "platforms": "nordicnrf52",
+  "build":
+  {
+    "libLDFMode": "chain+"
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/adafruit/Adafruit_nRF52_Arduino/issues/737

PlatformIO's default LDF search mode sees the code at 

https://github.com/adafruit/Adafruit_nRF52_Arduino/blob/10ed826056f9c0b3079129a3ec37c3a90ecb0585/libraries/Bluefruit52Lib/src/BLESecurity.h#L31-L33

and always includes the crypto lib.

Fix is turning up the [LDF mode](https://docs.platformio.org/en/latest/projectconf/section_env_library.html#lib-ldf-mode) ([2](https://docs.platformio.org/en/latest/librarymanager/ldf.html#dependency-finder-mode)) to one that evaluates the macro correctly and prevents the inclusion of the library when `NRF_CRYPTOCELL` is not defined for boards that don't have it.

I still have to test this..