### PR TITLE
Implemented thread-safe realloc and calloc

### DIFF
--- a/cores/nRF5/freertos/Source/include/portable.h
+++ b/cores/nRF5/freertos/Source/include/portable.h
@@ -128,6 +128,8 @@ void vPortDefineHeapRegions( const HeapRegion_t * const pxHeapRegions ) PRIVILEG
  */
 void *pvPortMalloc( size_t xSize ) PRIVILEGED_FUNCTION;
 void vPortFree( void *pv ) PRIVILEGED_FUNCTION;
+void *pvPortRealloc( void *ptr, size_t xWantedSize ) PRIVILEGED_FUNCTION;
+void *pvPortCalloc( size_t nmemb, size_t xWantedSize ) PRIVILEGED_FUNCTION;
 void vPortInitialiseBlocks( void ) PRIVILEGED_FUNCTION;
 size_t xPortGetFreeHeapSize( void ) PRIVILEGED_FUNCTION;
 size_t xPortGetMinimumEverFreeHeapSize( void ) PRIVILEGED_FUNCTION;

--- a/platform.txt
+++ b/platform.txt
@@ -49,7 +49,7 @@ compiler.elf2bin.flags=-O binary
 compiler.elf2bin.cmd=arm-none-eabi-objcopy
 compiler.elf2hex.flags=-O ihex
 compiler.elf2hex.cmd=arm-none-eabi-objcopy
-compiler.ldflags=-mcpu={build.mcu} -mthumb {build.float_flags} -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--wrap=malloc -Wl,--wrap=free --specs=nano.specs --specs=nosys.specs
+compiler.ldflags=-mcpu={build.mcu} -mthumb {build.float_flags} -Wl,--cref -Wl,--check-sections -Wl,--gc-sections -Wl,--unresolved-symbols=report-all -Wl,--warn-common -Wl,--warn-section-align -Wl,--wrap=malloc -Wl,--wrap=free -Wl,--wrap=realloc -Wl,--wrap=calloc --specs=nano.specs --specs=nosys.specs
 compiler.size.cmd=arm-none-eabi-size
 
 # this can be overriden in boards.txt


### PR DESCRIPTION
Hello everybody.
I have noticed that your FreeRTOS implementation only provides the threadsafe version of `malloc` and `free` while `realloc` and `calloc` are still not threadsafe. In case of very intense use of objects like `String` (which uses `realloc`) or in general of `realloc`/`calloc`, I noticed some hangs that I solved by implementing `pvPortRealloc` and `pvPortCalloc` and then wrapping the real `realloc` and `calloc` from the linker.
Hope it can help!