### PR TITLE
Add helper functions to HwPWM Instance

### DIFF
--- a/cores/nRF5/HardwarePWM.cpp
+++ b/cores/nRF5/HardwarePWM.cpp
@@ -205,6 +205,15 @@ bool HardwarePWM::removePin(uint8_t pin)
   return true;
 }
 
+bool HardwarePWM::removeAllPins(void)
+{
+  for(int ch=0; ch<MAX_CHANNELS; ch++)
+  {
+    _set_psel(ch, 0xFFFFFFFFUL);
+  }
+  return true;
+}
+
 bool HardwarePWM::writeChannel(uint8_t ch, uint16_t value, bool inverted)
 {
   VERIFY( ch < MAX_CHANNELS );

--- a/cores/nRF5/HardwarePWM.h
+++ b/cores/nRF5/HardwarePWM.h
@@ -68,12 +68,6 @@ class HardwarePWM
 
     void setClockDiv(uint8_t div);      // value is PWM_PRESCALER_PRESCALER_DIV_x, DIV1 is 16Mhz
 
-    // Direct access to peripheral base address
-    NRF_PWM_Type * const baseAddr(void)
-    {
-      return _pwm;
-    }
-
     // Cooperative ownership sharing
 
     // returns true ONLY when (1) no PWM channel has a pin, and (2) the owner token is nullptr

--- a/cores/nRF5/HardwarePWM.h
+++ b/cores/nRF5/HardwarePWM.h
@@ -94,6 +94,9 @@ class HardwarePWM
     // Remove a pin from PWM module
     bool removePin  (uint8_t pin);
 
+    // Remove all pins from PWM module
+    bool removeAllPins (void);
+
     // Get the mapped channel of a pin
     int  pin2channel(uint8_t pin) const
     {

--- a/cores/nRF5/HardwarePWM.h
+++ b/cores/nRF5/HardwarePWM.h
@@ -68,6 +68,12 @@ class HardwarePWM
 
     void setClockDiv(uint8_t div);      // value is PWM_PRESCALER_PRESCALER_DIV_x, DIV1 is 16Mhz
 
+    // Direct access to peripheral base address
+    NRF_PWM_Type * const baseAddr(void)
+    {
+      return _pwm;
+    }
+
     // Cooperative ownership sharing
 
     // returns true ONLY when (1) no PWM channel has a pin, and (2) the owner token is nullptr


### PR DESCRIPTION
These functions allow for full control of the PWM configuration when direct register access is required and supplies a necessary function to reset the HwPWM to its default configuration.

A typical workflow might be:
1.  ```takeOwnership``` of an available HwPWM instance through the standard API
2. lookup the ```baseAddr``` of that HwPWM instance if direct configuration using NRF_PWMx is required
3. configure the HwPWM
4. ```addPin```(s) as necessary to the HwPWM
5. ```enable``` the HwPWM
6. ```stop``` the HwPWM when finished
7. ```removeAllPins``` from the HwPWM
8. ```releaseOwnership``` and return the HwPWM instance back to the available pool 