### PR TITLE
Allow/Reject Pairing requests

### DIFF
--- a/libraries/Bluefruit52Lib/src/BLESecurity.h
+++ b/libraries/Bluefruit52Lib/src/BLESecurity.h
@@ -55,6 +55,8 @@ class BLESecurity
 
     // resolve address with IRK to see if it matches
     bool resolveAddress(ble_gap_addr_t const * p_addr, ble_gap_irk_t const * irk);
+    
+    void setPairable(bool pairable);
 
     //------------- Callbacks -------------//
     bool setPairPasskeyCallback(pair_passkey_cb_t fp);
@@ -74,6 +76,7 @@ class BLESecurity
 
   private:
     ble_gap_sec_params_t _sec_param;
+    bool _pairable;
 
 #ifdef NRF_CRYPTOCELL
     nRFCrypto_ECC_PrivateKey _private_key;


### PR DESCRIPTION
Hi,

I'm working on a board that does not have any Yes/No Button nor Display to accept or reject bonding requests.

I wanted to allow pairing based on a time window, which opens either on reset or when a dedicated button is pressed. This behaviour is common on several bluetooth hardwares. Well I could not figure out how to do that with the actual `BLESecurity` implementation.

Consequently, I added the `BLESecurity::setPairable` method. It controls an underlying flag. When set (default value) all requests are accepted, when `false`, they are all rejected.

I hope it helps, otherwise I'm opened to discussion.

Best regards,
Bigfoot38 