### PR TITLE
Add support for Immediate Alert Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /tools/.idea/
 /tools/midi_tests/node_modules
 
+.idea/
 .DS_Store
 *.swp
 /Output

--- a/libraries/Bluefruit52Lib/src/bluefruit.h
+++ b/libraries/Bluefruit52Lib/src/bluefruit.h
@@ -62,6 +62,7 @@
 #include "services/BLEDfu.h"
 #include "services/BLEUart.h"
 #include "services/BLEBas.h"
+#include "services/BLEIas.h"
 #include "services/BLEBeacon.h"
 #include "services/BLEHidGeneric.h"
 #include "services/BLEHidAdafruit.h"
@@ -75,6 +76,7 @@
 #include "clients/BLEClientCts.h"
 #include "clients/BLEClientHidAdafruit.h"
 #include "clients/BLEClientBas.h"
+#include "clients/BLEClientIas.h"
 
 #include "utility/AdaCallback.h"
 #include "utility/bonding.h"

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientIas.cpp
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientIas.cpp
@@ -5,19 +5,23 @@
 #include "BLEClientIas.h"
 #include "bluefruit.h"
 
-BLEClientIas::BLEClientIas() : BLEClientService(UUID16_SVC_IMMEDIATE_ALERT) {
+BLEClientIas::BLEClientIas() :
+BLEClientService(UUID16_SVC_IMMEDIATE_ALERT), _alert(UUID16_SVC_IMMEDIATE_ALERT) {
 
 }
 
 bool BLEClientIas::begin(void) {
     // invoke superclass begin()
     BLEClientService::begin();
+
+    _alert.begin(this);
+
     return true;
 }
 
 bool BLEClientIas::discover(uint16_t conn_handle) {
     VERIFY(BLEClientService::discover(conn_handle));
-
+    _conn_hdl = conn_handle;
     return true;
 }
 
@@ -26,11 +30,10 @@ uint16_t BLEClientIas::getAlertLevel() {
     uint8_t level = 0;
     ble_gattc_handle_range_t bck_range = Bluefruit.Discovery.getHandleRange();
 
-    BLEClientCharacteristic chr(uuid);
-    chr.begin(this);
+    _alert.begin(this);
 
-    if (Bluefruit.Discovery.discoverCharacteristic(_conn_hdl, chr)) {
-        level = chr.read8();
+    if (Bluefruit.Discovery.discoverCharacteristic(_conn_hdl, _alert)) {
+        level = _alert.read8();
     }
 
     Bluefruit.Discovery.setHandleRange(bck_range);

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientIas.cpp
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientIas.cpp
@@ -1,0 +1,5 @@
+//
+// Created by Charlie Bershatsky on 4/19/23.
+//
+
+#include "BLEClientIas.h"

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientIas.cpp
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientIas.cpp
@@ -23,13 +23,14 @@ bool BLEClientIas::discover(uint16_t conn_handle) {
 
 uint16_t BLEClientIas::getAlertLevel() {
 
-    uint16_t level = 0;
+    uint8_t level = 0;
+    ble_gattc_handle_range_t bck_range = Bluefruit.Discovery.getHandleRange();
 
     BLEClientCharacteristic chr(uuid);
     chr.begin(this);
 
     if (Bluefruit.Discovery.discoverCharacteristic(_conn_hdl, chr)) {
-        level = chr.read16();
+        level = chr.read8();
     }
 
     Bluefruit.Discovery.setHandleRange(bck_range);

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientIas.cpp
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientIas.cpp
@@ -3,3 +3,36 @@
 //
 
 #include "BLEClientIas.h"
+#include "bluefruit.h"
+
+BLEClientIas::BLEClientIas() : BLEClientService(UUID16_SVC_IMMEDIATE_ALERT) {
+
+}
+
+bool BLEClientIas::begin(void) {
+    // invoke superclass begin()
+    BLEClientService::begin();
+    return true;
+}
+
+bool BLEClientIas::discover(uint16_t conn_handle) {
+    VERIFY(BLEClientService::discover(conn_handle));
+
+    return true;
+}
+
+uint16_t BLEClientIas::getAlertLevel() {
+
+    uint16_t level = 0;
+
+    BLEClientCharacteristic chr(uuid);
+    chr.begin(this);
+
+    if (Bluefruit.Discovery.discoverCharacteristic(_conn_hdl, chr)) {
+        level = chr.read16();
+    }
+
+    Bluefruit.Discovery.setHandleRange(bck_range);
+
+    return level;
+}

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientIas.h
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientIas.h
@@ -5,8 +5,19 @@
 #ifndef ADAFRUIT_NRF52_ARDUINO_BLECLIENTIAS_H
 #define ADAFRUIT_NRF52_ARDUINO_BLECLIENTIAS_H
 
+#include "bluefruit_common.h"
+#include "BLEClientCharacteristic.h"
+#include "BLEClientService.h"
 
-class BLEClientIas {
+class BLEClientIas : public BLEClientService {
+
+public:
+    BLEClientIas(void);
+
+    virtual bool begin(void);
+    virtual bool discover(uint16_t conn_handle);
+
+    uint16_t getAlertLevel (void);
 
 };
 

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientIas.h
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientIas.h
@@ -19,6 +19,9 @@ public:
 
     uint16_t getAlertLevel (void);
 
+private:
+    BLEClientCharacteristic _alert;
+
 };
 
 

--- a/libraries/Bluefruit52Lib/src/clients/BLEClientIas.h
+++ b/libraries/Bluefruit52Lib/src/clients/BLEClientIas.h
@@ -1,0 +1,14 @@
+//
+// Created by Charlie Bershatsky on 4/19/23.
+//
+
+#ifndef ADAFRUIT_NRF52_ARDUINO_BLECLIENTIAS_H
+#define ADAFRUIT_NRF52_ARDUINO_BLECLIENTIAS_H
+
+
+class BLEClientIas {
+
+};
+
+
+#endif //ADAFRUIT_NRF52_ARDUINO_BLECLIENTIAS_H

--- a/libraries/Bluefruit52Lib/src/services/BLEIas.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEIas.cpp
@@ -1,0 +1,34 @@
+//
+// Created by Charlie Bershatsky on 4/19/23.
+//
+
+#include "BLEIas.h"
+#include "bluefruit.h"
+#include "utility/utilities.h"
+#include "BLEService.h"
+
+BLEIas::BLEIas(void) : BLEService(UUID16_SVC_IMMEDIATE_ALERT) {
+
+}
+
+void BLEIas::setAlertLevel(const uint8_t alert_level) {
+    _alert_level = alert_level;
+}
+
+err_t BLEIas::begin(void) {
+
+    // Invoke the superclass begin()
+    VERIFY_STATUS(BLEService::begin());
+
+    BLECharacteristic chars;
+
+    chars.setUuid(UUID16_CHR_ALERT_LEVEL);
+    chars.setTempMemory();
+    chars.setProperties(CHR_PROPS_READ);
+    chars.setFixedLen(sizeof(_alert_level));
+    VERIFY_STATUS(chars.begin());
+    chars.write(_alert_level, sizeof(_alert_level));
+
+    return ERROR_NONE;
+
+}

--- a/libraries/Bluefruit52Lib/src/services/BLEIas.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEIas.cpp
@@ -11,7 +11,7 @@ BLEIas::BLEIas(void) : BLEService(UUID16_SVC_IMMEDIATE_ALERT) {
 
 }
 
-void BLEIas::setAlertLevel(const uint8_t alert_level) {
+void BLEIas::setAlertLevel(uint8_t alert_level) {
     _alert_level = alert_level;
 }
 
@@ -27,7 +27,7 @@ err_t BLEIas::begin(void) {
     chars.setProperties(CHR_PROPS_READ);
     chars.setFixedLen(sizeof(_alert_level));
     VERIFY_STATUS(chars.begin());
-    chars.write(_alert_level, sizeof(_alert_level));
+    chars.write8(_alert_level);
 
     return ERROR_NONE;
 

--- a/libraries/Bluefruit52Lib/src/services/BLEIas.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEIas.cpp
@@ -7,12 +7,13 @@
 #include "utility/utilities.h"
 #include "BLEService.h"
 
-BLEIas::BLEIas(void) : BLEService(UUID16_SVC_IMMEDIATE_ALERT) {
+BLEIas::BLEIas(void) :
+BLEService(UUID16_SVC_IMMEDIATE_ALERT), _alert(UUID16_SVC_IMMEDIATE_ALERT) {
 
 }
 
-void BLEIas::setAlertLevel(uint8_t alert_level) {
-    _alert_level = alert_level;
+void BLEIas::write(uint8_t alert_level) {
+    _alert.write8(alert_level);
 }
 
 err_t BLEIas::begin(void) {
@@ -20,14 +21,11 @@ err_t BLEIas::begin(void) {
     // Invoke the superclass begin()
     VERIFY_STATUS(BLEService::begin());
 
-    BLECharacteristic chars;
+    _alert.setProperties(CHR_PROPS_READ);
+    _alert.setPermission(SECMODE_OPEN, SECMODE_NO_ACCESS);
+    _alert.setFixedLen(1);
 
-    chars.setUuid(UUID16_CHR_ALERT_LEVEL);
-    chars.setTempMemory();
-    chars.setProperties(CHR_PROPS_READ);
-    chars.setFixedLen(sizeof(_alert_level));
-    VERIFY_STATUS(chars.begin());
-    chars.write8(_alert_level);
+    VERIFY_STATUS( _alert.begin() );
 
     return ERROR_NONE;
 

--- a/libraries/Bluefruit52Lib/src/services/BLEIas.h
+++ b/libraries/Bluefruit52Lib/src/services/BLEIas.h
@@ -14,16 +14,12 @@
 class BLEIas : public BLEService {
 
 protected:
-    union {
-        struct {
-            uint8_t _alert_level; // UUID 0x2A06
-        };
-    };
+    BLECharacteristic _alert;
 
 public:
     BLEIas(void);
 
-    void setAlertLevel(uint8_t alert_level);
+    void write(uint8_t level);
 
     virtual err_t begin(void);
 

--- a/libraries/Bluefruit52Lib/src/services/BLEIas.h
+++ b/libraries/Bluefruit52Lib/src/services/BLEIas.h
@@ -16,7 +16,7 @@ class BLEIas : public BLEService {
 protected:
     union {
         struct {
-            const uint8_t _alert_level; // UUID 0x2A06
+            uint8_t _alert_level; // UUID 0x2A06
         };
     };
 

--- a/libraries/Bluefruit52Lib/src/services/BLEIas.h
+++ b/libraries/Bluefruit52Lib/src/services/BLEIas.h
@@ -1,0 +1,33 @@
+//
+// Created by Charlie Bershatsky on 4/19/23.
+//
+
+#ifndef ADAFRUIT_NRF52_ARDUINO_BLEIAS_H
+#define ADAFRUIT_NRF52_ARDUINO_BLEIAS_H
+
+#include "bluefruit_common.h"
+
+#include "BLEService.h"
+#include "BLECharacteristic.h"
+
+
+class BLEIas : public BLEService {
+
+protected:
+    union {
+        struct {
+            const uint8_t _alert_level; // UUID 0x2A06
+        };
+    };
+
+public:
+    BLEIas(void);
+
+    void setAlertLevel(uint8_t alert_level);
+
+    virtual err_t begin(void);
+
+};
+
+
+#endif //ADAFRUIT_NRF52_ARDUINO_BLEIAS_H


### PR DESCRIPTION
This PR modifies `bluefruit.h` and adds files to support instantiation and detection of the Immediate Alert service, or IAS. This service only has one characteristic - the 'alert level'. 