### PR TITLE
Ide2 debug

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -1,6 +1,6 @@
 menu.softdevice=SoftDevice
-menu.debug=Debug
-menu.debug_output=Debug Output
+menu.debug=Debug Level
+menu.debug_output=Debug Port
 
 # -----------------------------------
 # Adafruit Feather nRF52832
@@ -29,14 +29,15 @@ feather52832.build.usb_manufacturer="Adafruit"
 feather52832.build.usb_product="Feather nRF52832"
 feather52832.build.extra_flags=-DNRF52832_XXAA -DNRF52
 feather52832.build.ldscript=nrf52832_s132_v6.ld
+feather52832.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 
-# SoftDevice Menu
+# Menu: SoftDevice
 feather52832.menu.softdevice.s132v6=S132 6.1.1
 feather52832.menu.softdevice.s132v6.build.sd_name=s132
 feather52832.menu.softdevice.s132v6.build.sd_version=6.1.1
 feather52832.menu.softdevice.s132v6.build.sd_fwid=0x00B7
 
-# Debug Menu
+# Menu: Debug Level
 feather52832.menu.debug.l0=Level 0 (Release)
 feather52832.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 feather52832.menu.debug.l1=Level 1 (Error Message)
@@ -47,7 +48,7 @@ feather52832.menu.debug.l3=Level 3 (Segger SystemView)
 feather52832.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 feather52832.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 feather52832.menu.debug_output.serial=Serial
 feather52832.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 feather52832.menu.debug_output.serial1=Serial1
@@ -89,16 +90,17 @@ feather52840.build.usb_manufacturer="Adafruit"
 feather52840.build.usb_product="Feather nRF52840 Express"
 feather52840.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
 feather52840.build.ldscript=nrf52840_s140_v6.ld
+feather52840.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 feather52840.build.vid=0x239A
 feather52840.build.pid=0x8029
 
-# SoftDevice Menu
+# Menu: SoftDevice
 feather52840.menu.softdevice.s140v6=S140 6.1.1
 feather52840.menu.softdevice.s140v6.build.sd_name=s140
 feather52840.menu.softdevice.s140v6.build.sd_version=6.1.1
 feather52840.menu.softdevice.s140v6.build.sd_fwid=0x00B6
 
-# Debug Menu
+# Menu: Debug Level
 feather52840.menu.debug.l0=Level 0 (Release)
 feather52840.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 feather52840.menu.debug.l1=Level 1 (Error Message)
@@ -109,7 +111,7 @@ feather52840.menu.debug.l3=Level 3 (Segger SystemView)
 feather52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 feather52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 feather52840.menu.debug_output.serial=Serial
 feather52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 feather52840.menu.debug_output.serial1=Serial1
@@ -151,16 +153,17 @@ feather52840sense.build.usb_manufacturer="Adafruit"
 feather52840sense.build.usb_product="Feather nRF52840 Sense"
 feather52840sense.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
 feather52840sense.build.ldscript=nrf52840_s140_v6.ld
+feather52840sense.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 feather52840sense.build.vid=0x239A
 feather52840sense.build.pid=0x8087
 
-# SoftDevice Menu
+# Menu: SoftDevice
 feather52840sense.menu.softdevice.s140v6=S140 6.1.1
 feather52840sense.menu.softdevice.s140v6.build.sd_name=s140
 feather52840sense.menu.softdevice.s140v6.build.sd_version=6.1.1
 feather52840sense.menu.softdevice.s140v6.build.sd_fwid=0x00B6
 
-# Debug Menu
+# Menu: Debug Level
 feather52840sense.menu.debug.l0=Level 0 (Release)
 feather52840sense.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 feather52840sense.menu.debug.l1=Level 1 (Error Message)
@@ -171,7 +174,7 @@ feather52840sense.menu.debug.l3=Level 3 (Segger SystemView)
 feather52840sense.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 feather52840sense.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 feather52840sense.menu.debug_output.serial=Serial
 feather52840sense.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 feather52840sense.menu.debug_output.serial1=Serial1
@@ -213,16 +216,17 @@ itsybitsy52840.build.usb_manufacturer="Adafruit"
 itsybitsy52840.build.usb_product="ItsyBitsy nRF52840 Express"
 itsybitsy52840.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
 itsybitsy52840.build.ldscript=nrf52840_s140_v6.ld
+itsybitsy52840.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 itsybitsy52840.build.vid=0x239A
 itsybitsy52840.build.pid=0x8051
 
-# SoftDevice Menu
+# Menu: SoftDevice
 itsybitsy52840.menu.softdevice.s140v6=S140 6.1.1
 itsybitsy52840.menu.softdevice.s140v6.build.sd_name=s140
 itsybitsy52840.menu.softdevice.s140v6.build.sd_version=6.1.1
 itsybitsy52840.menu.softdevice.s140v6.build.sd_fwid=0x00B6
 
-# Debug Menu
+# Menu: Debug Level
 itsybitsy52840.menu.debug.l0=Level 0 (Release)
 itsybitsy52840.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 itsybitsy52840.menu.debug.l1=Level 1 (Error Message)
@@ -233,7 +237,7 @@ itsybitsy52840.menu.debug.l3=Level 3 (Segger SystemView)
 itsybitsy52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 itsybitsy52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 itsybitsy52840.menu.debug_output.serial=Serial
 itsybitsy52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 itsybitsy52840.menu.debug_output.serial1=Serial1
@@ -273,16 +277,17 @@ cplaynrf52840.build.usb_manufacturer="Adafruit"
 cplaynrf52840.build.usb_product="Circuit Playground Bluefruit"
 cplaynrf52840.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
 cplaynrf52840.build.ldscript=nrf52840_s140_v6.ld
+cplaynrf52840.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 cplaynrf52840.build.vid=0x239A
 cplaynrf52840.build.pid=0x8045
 
-# SoftDevice Menu
+# Menu: SoftDevice
 cplaynrf52840.menu.softdevice.s140v6=S140 6.1.1
 cplaynrf52840.menu.softdevice.s140v6.build.sd_name=s140
 cplaynrf52840.menu.softdevice.s140v6.build.sd_version=6.1.1
 cplaynrf52840.menu.softdevice.s140v6.build.sd_fwid=0x00B6
 
-# Debug Menu
+# Menu: Debug Level
 cplaynrf52840.menu.debug.l0=Level 0 (Release)
 cplaynrf52840.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 cplaynrf52840.menu.debug.l1=Level 1 (Error Message)
@@ -293,7 +298,7 @@ cplaynrf52840.menu.debug.l3=Level 3 (Segger SystemView)
 cplaynrf52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 cplaynrf52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 cplaynrf52840.menu.debug_output.serial=Serial
 cplaynrf52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 cplaynrf52840.menu.debug_output.serial1=Serial1
@@ -333,16 +338,17 @@ cluenrf52840.build.usb_manufacturer="Adafruit"
 cluenrf52840.build.usb_product="CLUE"
 cluenrf52840.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
 cluenrf52840.build.ldscript=nrf52840_s140_v6.ld
+cluenrf52840.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 cluenrf52840.build.vid=0x239A
 cluenrf52840.build.pid=0x8071
 
-# SoftDevice Menu
+# Menu: SoftDevice
 cluenrf52840.menu.softdevice.s140v6=S140 6.1.1
 cluenrf52840.menu.softdevice.s140v6.build.sd_name=s140
 cluenrf52840.menu.softdevice.s140v6.build.sd_version=6.1.1
 cluenrf52840.menu.softdevice.s140v6.build.sd_fwid=0x00B6
 
-# Debug Menu
+# Menu: Debug Level
 cluenrf52840.menu.debug.l0=Level 0 (Release)
 cluenrf52840.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 cluenrf52840.menu.debug.l1=Level 1 (Error Message)
@@ -353,7 +359,7 @@ cluenrf52840.menu.debug.l3=Level 3 (Segger SystemView)
 cluenrf52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 cluenrf52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 cluenrf52840.menu.debug_output.serial=Serial
 cluenrf52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 cluenrf52840.menu.debug_output.serial1=Serial1
@@ -393,16 +399,17 @@ ledglasses_nrf52840.build.usb_manufacturer="Adafruit"
 ledglasses_nrf52840.build.usb_product="LED Glasses Driver nRF52840"
 ledglasses_nrf52840.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
 ledglasses_nrf52840.build.ldscript=nrf52840_s140_v6.ld
+ledglasses_nrf52840.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 ledglasses_nrf52840.build.vid=0x239A
 ledglasses_nrf52840.build.pid=0x810D
 
-# SoftDevice Menu
+# Menu: SoftDevice
 ledglasses_nrf52840.menu.softdevice.s140v6=S140 6.1.1
 ledglasses_nrf52840.menu.softdevice.s140v6.build.sd_name=s140
 ledglasses_nrf52840.menu.softdevice.s140v6.build.sd_version=6.1.1
 ledglasses_nrf52840.menu.softdevice.s140v6.build.sd_fwid=0x00B6
 
-# Debug Menu
+# Menu: Debug Level
 ledglasses_nrf52840.menu.debug.l0=Level 0 (Release)
 ledglasses_nrf52840.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 ledglasses_nrf52840.menu.debug.l1=Level 1 (Error Message)
@@ -413,7 +420,7 @@ ledglasses_nrf52840.menu.debug.l3=Level 3 (Segger SystemView)
 ledglasses_nrf52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 ledglasses_nrf52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 ledglasses_nrf52840.menu.debug_output.serial=Serial
 ledglasses_nrf52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 ledglasses_nrf52840.menu.debug_output.serial1=Serial1
@@ -453,16 +460,17 @@ mdbt50qrx.build.usb_manufacturer="Raytac"
 mdbt50qrx.build.usb_product="nRF52840 Dongle"
 mdbt50qrx.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
 mdbt50qrx.build.ldscript=nrf52840_s140_v6.ld
+mdbt50qrx.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 mdbt50qrx.build.vid=0x239A
 mdbt50qrx.build.pid=0x810B
 
-# SoftDevice Menu
+# Menu: SoftDevice
 mdbt50qrx.menu.softdevice.s140v6=S140 6.1.1
 mdbt50qrx.menu.softdevice.s140v6.build.sd_name=s140
 mdbt50qrx.menu.softdevice.s140v6.build.sd_version=6.1.1
 mdbt50qrx.menu.softdevice.s140v6.build.sd_fwid=0x00B6
 
-# Debug Menu
+# Menu: Debug Level
 mdbt50qrx.menu.debug.l0=Level 0 (Release)
 mdbt50qrx.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 mdbt50qrx.menu.debug.l1=Level 1 (Error Message)
@@ -473,7 +481,7 @@ mdbt50qrx.menu.debug.l3=Level 3 (Segger SystemView)
 mdbt50qrx.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 mdbt50qrx.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 mdbt50qrx.menu.debug_output.serial=Serial
 mdbt50qrx.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 mdbt50qrx.menu.debug_output.serial1=Serial1
@@ -515,16 +523,17 @@ metro52840.build.usb_manufacturer="Adafruit"
 metro52840.build.usb_product="Metro nRF52840 Express"
 metro52840.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
 metro52840.build.ldscript=nrf52840_s140_v6.ld
+metro52840.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 metro52840.build.vid=0x239A
 metro52840.build.pid=0x803F
 
-# SoftDevice Menu
+# Menu: SoftDevice
 metro52840.menu.softdevice.s140v6=S140 6.1.1
 metro52840.menu.softdevice.s140v6.build.sd_name=s140
 metro52840.menu.softdevice.s140v6.build.sd_version=6.1.1
 metro52840.menu.softdevice.s140v6.build.sd_fwid=0x00B6
 
-# Debug Menu
+# Menu: Debug Level
 metro52840.menu.debug.l0=Level 0 (Release)
 metro52840.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 metro52840.menu.debug.l1=Level 1 (Error Message)
@@ -535,7 +544,7 @@ metro52840.menu.debug.l3=Level 3 (Segger SystemView)
 metro52840.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 metro52840.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 metro52840.menu.debug_output.serial=Serial
 metro52840.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 metro52840.menu.debug_output.serial1=Serial1
@@ -545,9 +554,8 @@ metro52840.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DE
 
 
 # -------------------------------------------------------
-#
 # Boards that aren't made by Adafruit
-#
+# and are not officially supported
 # -------------------------------------------------------
 
 # -----------------------------------
@@ -580,16 +588,17 @@ pca10056.build.usb_manufacturer="Nordic"
 pca10056.build.usb_product="nRF52840 DK"
 pca10056.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
 pca10056.build.ldscript=nrf52840_s140_v6.ld
+pca10056.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 pca10056.build.vid=0x239A
 pca10056.build.pid=0x8029
 
-# SoftDevice Menu
+# Menu: SoftDevice
 pca10056.menu.softdevice.s140v6=S140 6.1.1
 pca10056.menu.softdevice.s140v6.build.sd_name=s140
 pca10056.menu.softdevice.s140v6.build.sd_version=6.1.1
 pca10056.menu.softdevice.s140v6.build.sd_fwid=0x00B6
 
-# Debug Menu
+# Menu: Debug Level
 pca10056.menu.debug.l0=Level 0 (Release)
 pca10056.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 pca10056.menu.debug.l1=Level 1 (Error Message)
@@ -600,7 +609,7 @@ pca10056.menu.debug.l3=Level 3 (Segger SystemView)
 pca10056.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 pca10056.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 pca10056.menu.debug_output.serial=Serial
 pca10056.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 pca10056.menu.debug_output.serial1=Serial1
@@ -638,16 +647,17 @@ particle_xenon.build.usb_manufacturer="Particle"
 particle_xenon.build.usb_product="Xenon"
 particle_xenon.build.extra_flags=-DNRF52840_XXAA {build.flags.usb}
 particle_xenon.build.ldscript=nrf52840_s140_v6.ld
+particle_xenon.build.openocdscript=scripts/openocd/daplink_nrf52.cfg
 particle_xenon.build.vid=0x239A
 particle_xenon.build.pid=0x8029
 
-# SoftDevice Menu
+# Menu: SoftDevice
 particle_xenon.menu.softdevice.s140v6=S140 6.1.1
 particle_xenon.menu.softdevice.s140v6.build.sd_name=s140
 particle_xenon.menu.softdevice.s140v6.build.sd_version=6.1.1
 particle_xenon.menu.softdevice.s140v6.build.sd_fwid=0x00B6
 
-# Debug Menu
+# Menu: Debug Level
 particle_xenon.menu.debug.l0=Level 0 (Release)
 particle_xenon.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0
 particle_xenon.menu.debug.l1=Level 1 (Error Message)
@@ -658,7 +668,7 @@ particle_xenon.menu.debug.l3=Level 3 (Segger SystemView)
 particle_xenon.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3
 particle_xenon.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1
 
-# Debug Output Menu
+# Menu: Debug Port
 particle_xenon.menu.debug_output.serial=Serial
 particle_xenon.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0
 particle_xenon.menu.debug_output.serial1=Serial1

--- a/platform.txt
+++ b/platform.txt
@@ -128,11 +128,11 @@ recipe.size.regex.data=^(?:\.data|\.bss)\s+([0-9]+).*
 recipe.output.tmp_file={build.project_name}.hex
 recipe.output.save_file={build.project_name}.{build.variant}.hex
 
-#***************************************************
+# ------------------------------------------------
 # adafruit-nrfutil for uploading
 # https://github.com/adafruit/Adafruit_nRF52_nrfutil
 # pre-built binaries are provided for macos and windows
-#***************************************************
+# ------------------------------------------------
 tools.nrfutil.cmd=adafruit-nrfutil
 tools.nrfutil.cmd.windows={runtime.platform.path}/tools/adafruit-nrfutil/win32/adafruit-nrfutil.exe
 tools.nrfutil.cmd.macosx={runtime.platform.path}/tools/adafruit-nrfutil/macos/adafruit-nrfutil
@@ -141,9 +141,9 @@ tools.nrfutil.upload.params.verbose=--verbose
 tools.nrfutil.upload.params.quiet=
 tools.nrfutil.upload.pattern="{cmd}" {upload.verbose} dfu serial -pkg "{build.path}/{build.project_name}.zip" -p {serial.port} -b 115200 --singlebank
 
-#***************************************************
+# ---------------------------------------------------
 # Burning bootloader with either jlink or nrfutil
-#***************************************************
+# ---------------------------------------------------
 
 # Bootloader version
 tools.bootburn.bootloader.file={runtime.platform.path}/bootloader/{build.variant}/{build.variant}_bootloader-0.6.2_{build.sd_name}_{build.sd_version}
@@ -157,3 +157,26 @@ tools.bootburn.erase.params.verbose=
 tools.bootburn.erase.params.quiet=
 tools.bootburn.erase.pattern=
 
+# ----------------------------------------
+# Debugger configuration (general options)
+# ----------------------------------------
+# EXPERIMENTAL feature:
+#  - this is alpha and may be subject to change without notice
+debug.executable={build.path}/{build.project_name}.elf
+debug.toolchain=gcc
+debug.toolchain.path={runtime.tools.arm-none-eabi-gcc.path}/bin/
+debug.toolchain.prefix=arm-none-eabi-
+
+debug.server=openocd
+debug.server.openocd.path={runtime.tools.openocd-0.11.0-arduino2.path}/bin/openocd
+debug.server.openocd.scripts_dir={runtime.tools.openocd-0.11.0-arduino2.path}/share/openocd/scripts/
+debug.server.openocd.script={runtime.platform.path}/{build.openocdscript}
+
+# JLinkServer is not supported by arduino-cli yet
+#   https://github.com/arduino/arduino-cli/blob/eca9d9a8f00582a08fadea8a4b7e3ef01b40d082/commands/debug/debug.go#L160
+# use debug_custom.json to run JLinkGDBServer instead
+#   https://docs.arduino.cc/tutorials/mkr-wifi-1010/mkr-jlink-setup
+#debug.server=jlink
+#debug.server.jlink.path=JLinkGDBServer
+#debug.server.jlink.device=nrf52840_xxaa
+#debug.server.jlink.script={runtime.platform.path}/{build.openocdscript}

--- a/scripts/jlink/debug_custom.json
+++ b/scripts/jlink/debug_custom.json
@@ -1,0 +1,6 @@
+{
+  "servertype": "jlink",
+  "device": "nrf52840_xxaa",
+  "interface": "SWD",
+  "serverpath": "JLinkGDBServer"
+}

--- a/scripts/openocd/daplink_nrf52.cfg
+++ b/scripts/openocd/daplink_nrf52.cfg
@@ -1,0 +1,3 @@
+source [find interface/cmsis-dap.cfg]
+transport select swd
+source [find target/nrf52.cfg]

--- a/scripts/openocd/jlink_nrf52.cfg
+++ b/scripts/openocd/jlink_nrf52.cfg
@@ -1,0 +1,3 @@
+source [find interface/jlink.cfg]
+transport select swd
+source [find target/nrf52.cfg]

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -26,18 +26,18 @@ def get_mcu(name):
 def build_upload(name):
     mcu = get_mcu(name)
     print("# Upload")
-    print("%s.bootloader.tool=bootburn" % name)
-    print("%s.upload.tool=nrfutil" % name)
-    print("%s.upload.protocol=nrfutil" % name)
+    print(f"{name}.bootloader.tool=bootburn")
+    print(f"{name}.upload.tool=nrfutil")
+    print(f"{name}.upload.protocol=nrfutil")
     if mcu == 52832:
-        print("%s.upload.use_1200bps_touch=false" % name)
-        print("%s.upload.wait_for_upload_port=false" % name)
-        print("%s.upload.native_usb=false" % name)
+        print(f"{name}.upload.use_1200bps_touch=false")
+        print(f"{name}.upload.wait_for_upload_port=false")
+        print(f"{name}.upload.native_usb=false")
     else:
-        print("%s.upload.use_1200bps_touch=true" % name)
-        print("%s.upload.wait_for_upload_port=true" % name)
-    print("%s.upload.maximum_size=%d" % (name, mcu_dict[mcu]['flash_size']))
-    print("%s.upload.maximum_data_size=%d" % (name, mcu_dict[mcu]['data_size']))
+        print(f"{name}.upload.use_1200bps_touch=true")
+        print(f"{name}.upload.wait_for_upload_port=true")
+    print(f"{name}.upload.maximum_size={mcu_dict[mcu]['flash_size']}")
+    print(f"{name}.upload.maximum_data_size={mcu_dict[mcu]['data_size']}")
     print()
 
 
@@ -45,73 +45,73 @@ def build_header(name, variant, vendor_name, product_name, boarddefine, vid, pid
     prettyname = vendor_name + " " + product_name
     print()
     print("# -----------------------------------")
-    print("# %s" % prettyname)
+    print(f"# {prettyname}")
     print("# -----------------------------------")
-    print("%s.name=%s" % (name, prettyname))
+    print(f"{name}.name={prettyname}")
     print()
 
     print("# VID/PID for Bootloader, Arduino & CircuitPython")
     for i in range(len(pid_list)):
-        print("%s.vid.%d=%s" % (name, i, vid))
-        print("%s.pid.%d=%s" % (name, i, pid_list[i]))
+        print(f"{name}.vid.{i}={vid}")
+        print(f"{name}.pid.{i}={pid_list[i]}")
     print()
 
     build_upload(name)
 
     print("# Build")
-    print("%s.build.mcu=cortex-m4" % name)
-    print("%s.build.f_cpu=64000000" % name)
-    print("%s.build.board=%s" % (name, boarddefine))
-    print("%s.build.core=nRF5" % name)
-    print("%s.build.variant=%s" % (name, variant))
-    print('%s.build.usb_manufacturer="%s"' % (name, vendor_name))
-    print('%s.build.usb_product="%s"' % (name, product_name))
+    print(f"{name}.build.mcu=cortex-m4")
+    print(f"{name}.build.f_cpu=64000000")
+    print(f"{name}.build.board={boarddefine}")
+    print(f"{name}.build.core=nRF5")
+    print(f"{name}.build.variant={variant}")
+    print(f'{name}.build.usb_manufacturer="{vendor_name}"')
+    print(f'{name}.build.usb_product="{product_name}"')
 
     mcu = get_mcu(name)
-    print("%s.build.extra_flags=%s" % (name, mcu_dict[mcu]['extra_flags']))
-    print("%s.build.ldscript=%s" % (name, mcu_dict[mcu]['ldscript']))
+    print(f"{name}.build.extra_flags={mcu_dict[mcu]['extra_flags']}")
+    print(f"{name}.build.ldscript={mcu_dict[mcu]['ldscript']}")
     if mcu != 52832:
-        print("%s.build.vid=%s" % (name, vid))
-        print("%s.build.pid=%s" % (name, pid_list[0]))
+        print(f"{name}.build.vid={vid}")
+        print(f"{name}.build.pid={pid_list[0]}")
     print()
 
 
 def build_softdevice(name):
     print("# SoftDevice Menu")
     if get_mcu(name) == 52832:
-        print("%s.menu.softdevice.s132v6=S132 6.1.1" % name)
-        print("%s.menu.softdevice.s132v6.build.sd_name=s132" % name)
-        print("%s.menu.softdevice.s132v6.build.sd_version=6.1.1" % name)
-        print("%s.menu.softdevice.s132v6.build.sd_fwid=0x00B7" % name)
+        print(f"{name}.menu.softdevice.s132v6=S132 6.1.1")
+        print(f"{name}.menu.softdevice.s132v6.build.sd_name=s132")
+        print(f"{name}.menu.softdevice.s132v6.build.sd_version=6.1.1")
+        print(f"{name}.menu.softdevice.s132v6.build.sd_fwid=0x00B7")
     else:
-        print("%s.menu.softdevice.s140v6=S140 6.1.1" % name)
-        print("%s.menu.softdevice.s140v6.build.sd_name=s140" % name)
-        print("%s.menu.softdevice.s140v6.build.sd_version=6.1.1" % name)
-        print("%s.menu.softdevice.s140v6.build.sd_fwid=0x00B6" % name)
+        print(f"{name}.menu.softdevice.s140v6=S140 6.1.1")
+        print(f"{name}.menu.softdevice.s140v6.build.sd_name=s140")
+        print(f"{name}.menu.softdevice.s140v6.build.sd_version=6.1.1")
+        print(f"{name}.menu.softdevice.s140v6.build.sd_fwid=0x00B6")
     print()
 
 
 def build_debug(name):
     print("# Debug Menu")
-    print("%s.menu.debug.l0=Level 0 (Release)" % name)
-    print("%s.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0" % name)
-    print("%s.menu.debug.l1=Level 1 (Error Message)" % name)
-    print("%s.menu.debug.l1.build.debug_flags=-DCFG_DEBUG=1" % name)
-    print("%s.menu.debug.l2=Level 2 (Full Debug)" % name)
-    print("%s.menu.debug.l2.build.debug_flags=-DCFG_DEBUG=2" % name)
-    print("%s.menu.debug.l3=Level 3 (Segger SystemView)" % name)
-    print("%s.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3" % name)
-    print("%s.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1" % name)
+    print(f"{name}.menu.debug.l0=Level 0 (Release)")
+    print(f"{name}.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0")
+    print(f"{name}.menu.debug.l1=Level 1 (Error Message)")
+    print(f"{name}.menu.debug.l1.build.debug_flags=-DCFG_DEBUG=1")
+    print(f"{name}.menu.debug.l2=Level 2 (Full Debug)")
+    print(f"{name}.menu.debug.l2.build.debug_flags=-DCFG_DEBUG=2")
+    print(f"{name}.menu.debug.l3=Level 3 (Segger SystemView)")
+    print(f"{name}.menu.debug.l3.build.debug_flags=-DCFG_DEBUG=3")
+    print(f"{name}.menu.debug.l3.build.sysview_flags=-DCFG_SYSVIEW=1")
     print()
 
 def build_debug_output(name):
     print("# Debug Output Menu")
-    print("%s.menu.debug_output.serial=Serial" % name)
-    print("%s.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0" % name)
-    print("%s.menu.debug_output.serial1=Serial1" % name)
-    print("%s.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG" % name)
-    print("%s.menu.debug_output.rtt=Segger RTT" % name)
-    print("%s.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL" % name)
+    print(f"{name}.menu.debug_output.serial=Serial")
+    print(f"{name}.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0")
+    print(f"{name}.menu.debug_output.serial1=Serial1")
+    print(f"{name}.menu.debug_output.serial1.build.logger_flags=-DCFG_LOGGER=1 -DCFG_TUSB_DEBUG=CFG_DEBUG")
+    print(f"{name}.menu.debug_output.rtt=Segger RTT")
+    print(f"{name}.menu.debug_output.rtt.build.logger_flags=-DCFG_LOGGER=2 -DCFG_TUSB_DEBUG=CFG_DEBUG -DSEGGER_RTT_MODE_DEFAULT=SEGGER_RTT_MODE_BLOCK_IF_FIFO_FULL")
 
 def build_global_menu():
     print("menu.softdevice=SoftDevice")
@@ -125,44 +125,65 @@ def make_board(name, variant, vendor_name, product_name, boarddefine, vid, pid_l
     build_debug_output(name)
 
 
+# ------------------------------
+# main
+# ------------------------------
 build_global_menu()
 
-make_board("feather52832", "feather_nrf52832", "Adafruit", "Feather nRF52832", "NRF52832_FEATHER",
-           "0x239A", [])
-make_board("feather52840", "feather_nrf52840_express", "Adafruit", "Feather nRF52840 Express", "NRF52840_FEATHER",
-           "0x239A", ["0x8029", "0x0029", "0x002A", "0x802A"])
+# ------------------------------
+# Adafruit Boards
+# ------------------------------
 
-make_board("feather52840sense", "feather_nrf52840_sense", "Adafruit", "Feather nRF52840 Sense", "NRF52840_FEATHER_SENSE",
-           "0x239A", ["0x8087", "0x0087", "0x0088", "0x8088"])
+adafruit_boards_list = [
+    ["feather52832", "feather_nrf52832", "Adafruit", "Feather nRF52832", "NRF52832_FEATHER",
+     "0x239A", []],
 
-make_board("itsybitsy52840", "itsybitsy_nrf52840_express", "Adafruit", "ItsyBitsy nRF52840 Express", "NRF52840_ITSYBITSY -DARDUINO_NRF52_ITSYBITSY",
-           "0x239A", ["0x8051", "0x0051", "0x0052", "0x8052"])
+    ["feather52840", "feather_nrf52840_express", "Adafruit", "Feather nRF52840 Express", "NRF52840_FEATHER",
+     "0x239A", ["0x8029", "0x0029", "0x002A", "0x802A"]],
 
-make_board("cplaynrf52840", "circuitplayground_nrf52840", "Adafruit", "Circuit Playground Bluefruit", "NRF52840_CIRCUITPLAY",
-           "0x239A", ["0x8045", "0x0045", "0x8046"])
+    ["feather52840sense", "feather_nrf52840_sense", "Adafruit", "Feather nRF52840 Sense", "NRF52840_FEATHER_SENSE",
+     "0x239A", ["0x8087", "0x0087", "0x0088", "0x8088"]],
 
-make_board("cluenrf52840", "clue_nrf52840", "Adafruit", "CLUE", "NRF52840_CLUE",
-           "0x239A", ["0x8071", "0x0071", "0x8072"])
+    ["itsybitsy52840", "itsybitsy_nrf52840_express", "Adafruit", "ItsyBitsy nRF52840 Express", "NRF52840_ITSYBITSY -DARDUINO_NRF52_ITSYBITSY",
+     "0x239A", ["0x8051", "0x0051", "0x0052", "0x8052"]],
 
-make_board("ledglasses_nrf52840", "ledglasses_nrf52840", "Adafruit", "LED Glasses Driver nRF52840", "NRF52840_LED_GLASSES",
-           "0x239A", ["0x810D", "0x010D", "0x810E"])
+    ["cplaynrf52840", "circuitplayground_nrf52840", "Adafruit", "Circuit Playground Bluefruit", "NRF52840_CIRCUITPLAY",
+     "0x239A", ["0x8045", "0x0045", "0x8046"]],
 
-make_board("mdbt50qrx", "raytac_mdbt50q_rx", "Raytac", "nRF52840 Dongle", "MDBT50Q_RX",
-           "0x239A", ["0x810B", "0x010B", "0x810C"])
+    ["cluenrf52840", "clue_nrf52840", "Adafruit", "CLUE", "NRF52840_CLUE",
+     "0x239A", ["0x8071", "0x0071", "0x8072"]],
 
-make_board("metro52840", "metro_nrf52840_express", "Adafruit", "Metro nRF52840 Express", "NRF52840_METRO",
-           "0x239A", ["0x803F", "0x003F", "0x0040", "0x8040"])
+    ["ledglasses_nrf52840", "ledglasses_nrf52840", "Adafruit", "LED Glasses Driver nRF52840", "NRF52840_LED_GLASSES",
+     "0x239A", ["0x810D", "0x010D", "0x810E"]],
+
+    ["mdbt50qrx", "raytac_mdbt50q_rx", "Raytac", "nRF52840 Dongle", "MDBT50Q_RX",
+     "0x239A", ["0x810B", "0x010B", "0x810C"]],
+
+    ["metro52840", "metro_nrf52840_express", "Adafruit", "Metro nRF52840 Express", "NRF52840_METRO",
+     "0x239A", ["0x803F", "0x003F", "0x0040", "0x8040"]],
+]
+
+for b in adafruit_boards_list:
+    make_board(*b)
+
+# ------------------------------
+# 3rd Party Boards
+# ------------------------------
 
 print()
 print()
 print("# -------------------------------------------------------")
-print("#")
 print("# Boards that aren't made by Adafruit")
-print("#")
+print("# and are not officially supported")
 print("# -------------------------------------------------------")
 
-make_board("pca10056", "pca10056", "Nordic", "nRF52840 DK", "NRF52840_PCA10056",
-           "0x239A", ["0x8029", "0x0029"])
+thirdparty_boards_list = [
+    ["pca10056", "pca10056", "Nordic", "nRF52840 DK", "NRF52840_PCA10056",
+     "0x239A", ["0x8029", "0x0029"]],
 
-make_board("particle_xenon", "particle_xenon", "Particle", "Xenon", "PARTICLE_XENON",
-           "0x239A", ["0x8029", "0x0029"])
+    ["particle_xenon", "particle_xenon", "Particle", "Xenon", "PARTICLE_XENON",
+     "0x239A", ["0x8029", "0x0029"]],
+]
+
+for b in thirdparty_boards_list:
+    make_board(*b)

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -70,6 +70,7 @@ def build_header(name, variant, vendor_name, product_name, boarddefine, vid, pid
     mcu = get_mcu(name)
     print(f"{name}.build.extra_flags={mcu_dict[mcu]['extra_flags']}")
     print(f"{name}.build.ldscript={mcu_dict[mcu]['ldscript']}")
+    print(f"{name}.build.openocdscript=scripts/openocd/daplink_nrf52.cfg")
     if mcu != 52832:
         print(f"{name}.build.vid={vid}")
         print(f"{name}.build.pid={pid_list[0]}")
@@ -77,7 +78,7 @@ def build_header(name, variant, vendor_name, product_name, boarddefine, vid, pid
 
 
 def build_softdevice(name):
-    print("# SoftDevice Menu")
+    print("# Menu: SoftDevice")
     if get_mcu(name) == 52832:
         print(f"{name}.menu.softdevice.s132v6=S132 6.1.1")
         print(f"{name}.menu.softdevice.s132v6.build.sd_name=s132")
@@ -92,7 +93,7 @@ def build_softdevice(name):
 
 
 def build_debug(name):
-    print("# Debug Menu")
+    print("# Menu: Debug Level")
     print(f"{name}.menu.debug.l0=Level 0 (Release)")
     print(f"{name}.menu.debug.l0.build.debug_flags=-DCFG_DEBUG=0")
     print(f"{name}.menu.debug.l1=Level 1 (Error Message)")
@@ -105,7 +106,7 @@ def build_debug(name):
     print()
 
 def build_debug_output(name):
-    print("# Debug Output Menu")
+    print("# Menu: Debug Port")
     print(f"{name}.menu.debug_output.serial=Serial")
     print(f"{name}.menu.debug_output.serial.build.logger_flags=-DCFG_LOGGER=0")
     print(f"{name}.menu.debug_output.serial1=Serial1")
@@ -115,8 +116,8 @@ def build_debug_output(name):
 
 def build_global_menu():
     print("menu.softdevice=SoftDevice")
-    print("menu.debug=Debug")
-    print("menu.debug_output=Debug Output")
+    print("menu.debug=Debug Level")
+    print("menu.debug_output=Debug Port")
 
 def make_board(name, variant, vendor_name, product_name, boarddefine, vid, pid_list):
     build_header(name, variant, vendor_name, product_name, boarddefine, vid, pid_list)


### PR DESCRIPTION
- add support for IDE v2 debug with openocd + cmsis-dap probe such as pi debug probe.
- jlink over openocd cfg is also added for reference. However due to IDEv2 issue that only pick up default build.openocdscript (and ignore menu selection value). User with jlink want to debug can either use debug_custom.json or change the to jlink_nrf52.cfg instead

Ref: similar to https://github.com/adafruit/ArduinoCore-samd/pull/346

![image](https://github.com/adafruit/Adafruit_nRF52_Arduino/assets/249515/757c65f1-d806-4d24-8b27-b3ec35d51adf)
