### PR TITLE
fix space in path issue when burning bootloader with IDE v2

### DIFF
--- a/programmers.txt
+++ b/programmers.txt
@@ -27,7 +27,7 @@ nrfutil_boot.program.cmd.windows={runtime.platform.path}/tools/adafruit-nrfutil/
 nrfutil_boot.program.cmd.macosx={runtime.platform.path}/tools/adafruit-nrfutil/macos/adafruit-nrfutil
 
 # Burn bootloader pattern
-nrfutil_boot.program.burn_pattern={program.cmd} --verbose dfu serial -pkg "{bootloader.file}.zip" -p {serial.port} -b 115200 --touch 1200
+nrfutil_boot.program.burn_pattern="{program.cmd}" --verbose dfu serial -pkg "{bootloader.file}.zip" -p {serial.port} -b 115200 --touch 1200
 
 # Remind user to select Jlink when used to upload sketch
 nrfutil_boot.program.params.quiet=


### PR DESCRIPTION
ref https://forums.adafruit.com/viewtopic.php?t=202304