### PR TITLE
FIX #197 : Replace varclr with arrclr for BLEAdvertising _data fields

### DIFF
--- a/libraries/Bluefruit52Lib/src/BLEAdvertising.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEAdvertising.cpp
@@ -42,7 +42,7 @@
 BLEAdvertisingData::BLEAdvertisingData(void)
 {
   _count = 0;
-  varclr(_data);
+  arrclr(_data);
 }
 
 bool BLEAdvertisingData::addData(uint8_t type, const void* data, uint8_t len)
@@ -242,7 +242,7 @@ bool BLEAdvertisingData::setData(uint8_t const * data, uint8_t count)
 void BLEAdvertisingData::clearData(void)
 {
   _count = 0;
-  varclr(_data);
+  arrclr(_data);
 }
 
 /*------------------------------------------------------------------*/


### PR DESCRIPTION
Otherwise the data field gets corrupted (?) causing error msg "bool BLEAdvertising::_start(uint16_t, uint16_t): 364: verify failed, error = NRF_ERROR_INVALID_LENGTH" as mentioned in this comment: https://github.com/adafruit/Adafruit_nRF52_Arduino/issues/197#issuecomment-1403674667

This apparently does not cause any issue when advertising the first time but when calling BLEAdvertising#clearData(), e.g. for changing the advertised bluetooth device name "on the fly", then starting the new advertisement procedure will fail.

see also https://devzone.nordicsemi.com/f/nordic-q-a/52573/sd_ble_gap_adv_set_configure-returns-error-nrf_error_invalid_length