### PR TITLE
Attempt to add PHY coded support to Adafruit API

### DIFF
--- a/libraries/Bluefruit52Lib/src/BLEAdvertising.h
+++ b/libraries/Bluefruit52Lib/src/BLEAdvertising.h
@@ -72,7 +72,8 @@ class Advertisable
 class BLEAdvertisingData
 {
 protected:
-  uint8_t _data[BLE_GAP_ADV_SET_DATA_SIZE_MAX];
+  uint8_t _max_data_size;
+  uint8_t _data[BLE_GAP_ADV_SET_DATA_SIZE_EXTENDED_MAX_SUPPORTED];
   uint8_t _count;
 
 public:
@@ -121,6 +122,10 @@ public:
   BLEAdvertising(void);
 
   void setType(uint8_t adv_type);
+  void setPrimaryPhy(uint8_t primary_phy);
+  void setSecondaryPhy(uint8_t secondary_phy);
+  void setFilterPolicy(uint8_t filter_policy);
+  void setMaxAdvEvts(uint8_t max_adv_evts);
   void setFastTimeout(uint16_t sec);
 
   void setSlowCallback(slow_callback_t fp);
@@ -150,6 +155,10 @@ public:
 private:
   uint8_t  _hdl;
   uint8_t  _type;
+  uint8_t  _primary_phy;
+  uint8_t  _secondary_phy;
+  uint8_t  _filter_policy;
+  uint8_t  _max_adv_evts;
   bool     _start_if_disconnect;
   bool     _runnning;
 


### PR DESCRIPTION
This change attempts to update the Bluefruit52 library to enable access to a few of Nordic's API settings with the hope of using BLE long-range advertising (PHY coded).  I applied these changes to an Adafruit ItsyBitsy nRF52840 Express board, attempted to advertise, and was unsuccessful with having a BT sniffer pick up the advertisements. Therefore, please review the changes well and let me know if there is an error.

I am using a second Adafruit ItsyBitsy nRF52840 Express with Wireshark to serve as the sniffer. The nRF Sniffer plug-in is set to pick up PHY coded advertisements. I share this because I cannot isolate the root cause with the hardware that I have available:
1. The board may not be capable of PHY coded advertisements and/or sniffing
2. nRF's software may not be correctly sniffing PHY coded
3. The code in this pull request is wrong
4. My application's use of the API is wrong.

If someone has enabled this functionality on one of the boards, please consider sharing the settings used.