### PR TITLE
Fix _irq_handler

### DIFF
--- a/libraries/RotaryEncoder/SwRotaryEncoder.cpp
+++ b/libraries/RotaryEncoder/SwRotaryEncoder.cpp
@@ -120,14 +120,14 @@ void SwRotaryEncoder::clearAbs(void)
 
 void SwRotaryEncoder::_irq_handler(void)
 {
-  uint32_t val = NRF_GPIO->IN;
-  uint8_t bita = bitRead(val, _pina);
+  uint8_t bita = digitalRead(_pina);
+  uint8_t bitb = digitalRead(_pinb);
 
   if ( bita != _a_last)
   {
     int32_t step;
 
-    if ( bita != bitRead(val, _pinb) )
+    if ( bita != bitb )
     {
       step = 1;
     }else


### PR DESCRIPTION
I'm working on a project that has 3 rotary encoders. When I used this libary, I couldn't get the 3 switches to properly increment / decrement the steps when I called readAbs(). Looking back at the code, I see there was a change in 351cd82 which seemed to have caused the issue.

If I look previous to 351cd82, the _irq_handler was using digitalRead. I think switching to bitRead caused a mix up between the physical pin number vs. the port pin? I'm not entirely sure. I reimplemented the pre 351cd82 code and used the new ada_callback. Seems to be working great now!