### PR TITLE
add availableForWrite() for uart

### DIFF
--- a/cores/nRF5/HardwareSerial.h
+++ b/cores/nRF5/HardwareSerial.h
@@ -70,6 +70,7 @@ class HardwareSerial : public Stream
     virtual void flush(void) = 0;
     virtual size_t write(uint8_t) = 0;
     virtual size_t write(const uint8_t *buffer, size_t size) = 0;
+    virtual int availableForWrite(void);
     using Print::write; // pull in write(str) from Print
     virtual operator bool() = 0;
 };

--- a/cores/nRF5/RingBuffer.cpp
+++ b/cores/nRF5/RingBuffer.cpp
@@ -67,6 +67,14 @@ int RingBuffer::available()
 		return delta;
 }
 
+int RingBuffer::availableForStore() {
+  if (_iHead >= _iTail) {
+    return SERIAL_BUFFER_SIZE - 1 - _iHead + _iTail;
+  } else {
+    return _iTail - _iHead - 1;
+  }
+}
+
 int RingBuffer::peek()
 {
 	if(_iTail == _iHead)

--- a/cores/nRF5/RingBuffer.h
+++ b/cores/nRF5/RingBuffer.h
@@ -39,14 +39,15 @@ class RingBuffer
   public:
     RingBuffer( void ) ;
     void store_char( uint8_t c ) ;
-	void clear();
-	int read_char();
-	int available();
-	int peek();
-	bool isFull();
+    void clear();
+    int read_char();
+    int available();
+    int availableForStore();
+    int peek();
+    bool isFull();
 
   private:
-	int nextIndex(int index);
+    int nextIndex(int index);
 } ;
 
 #endif /* _RING_BUFFER_ */

--- a/cores/nRF5/Uart.cpp
+++ b/cores/nRF5/Uart.cpp
@@ -253,6 +253,12 @@ size_t Uart::write(const uint8_t *buffer, size_t size)
   return sent;
 }
 
+int Uart::availableForWrite(void) {
+  // UART does not use ring buffer for TX, therefore it is either busy or not
+  UBaseType_t available = uxSemaphoreGetCount(_end_tx_sem);
+  return available ? SERIAL_BUFFER_SIZE : 0;
+}
+
 //------------- Serial1 (or Serial in case of nRF52832) -------------//
 #ifdef NRF52832_XXAA
   Uart Serial( NRF_UARTE0, UARTE0_UART0_IRQn, PIN_SERIAL_RX, PIN_SERIAL_TX );

--- a/cores/nRF5/Uart.h
+++ b/cores/nRF5/Uart.h
@@ -39,6 +39,7 @@ class Uart : public HardwareSerial
     void begin(unsigned long baudrate, uint16_t config);
     void end();
     int available();
+    int availableForWrite(void);
     int peek();
     int read();
     void flush();


### PR DESCRIPTION
add availableForWrite() for uart. Since UART does not use ring buffer for TX, therefore it is either busy or not. Fix #750