### PR TITLE
Line 199, BLEScanner::checkReportForUuid -- Remove const specifier fr…

### DIFF
--- a/libraries/Bluefruit52Lib/src/BLEScanner.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEScanner.cpp
@@ -196,7 +196,7 @@ uint8_t BLEScanner::parseReportByType(const ble_gap_evt_adv_report_t* report, ui
 
 bool BLEScanner::checkReportForUuid(const ble_gap_evt_adv_report_t* report, BLEUuid ble_uuid)
 {
-  const uint8_t* uuid;
+  uint8_t* uuid;
   uint8_t uuid_len = ble_uuid.size();
 
   uint8_t type_arr[2];
@@ -213,7 +213,7 @@ bool BLEScanner::checkReportForUuid(const ble_gap_evt_adv_report_t* report, BLEU
     type_arr[0] = BLE_GAP_AD_TYPE_128BIT_SERVICE_UUID_MORE_AVAILABLE;
     type_arr[1] = BLE_GAP_AD_TYPE_128BIT_SERVICE_UUID_COMPLETE;
 
-    uuid = ble_uuid._uuid128;
+    uuid = (uint8_t*) ble_uuid._uuid128;
   }
 
   uuid_len /= 8; // convert to number of bytes


### PR DESCRIPTION
…om uuid variable.

The local variable uuid in function bool BLEScanner::checkReportForUuid was defined as const, but it was not initialized with a value and is later assigned one (on lines 210 or 216). A const variable must be declared with an initial value, which cannot be changed. What is needed here is not a const value, but a cast where uuid was assigned a value. This was done correctly in one spot, but not on the other.