### PR TITLE
increase SD ram for nrf52832

### DIFF
--- a/cores/nRF5/linker/nrf52832_s132_v6.ld
+++ b/cores/nRF5/linker/nrf52832_s132_v6.ld
@@ -14,7 +14,7 @@ MEMORY
    * - Concurrent connection peripheral + central + secure links
    * - Event Len, HVN queue, Write CMD queue
    */ 
-  RAM (rwx) :  ORIGIN = 0x20003600, LENGTH = 0x20010000 - 0x20003600
+  RAM (rwx) :  ORIGIN = 0x20005600, LENGTH = 0x20010000 - 0x20005600
 }
 
 SECTIONS


### PR DESCRIPTION
Running out of memory with included linker file.

```
BSP Library : 1.6.0
Bootloader  : s132 6.1.1
Serial No   : 6BF6CDFE7D52A249

[CFG   ] SoftDevice config require more SRAM than provided by linker.
App Ram Start must be at least 0x20004730 (provided 0x20003600)
Please update linker file or re-config SoftDevice
[CFG   ] SoftDevice's RAM requires: 0x20004730
bool AdafruitBluefruit::begin(uint8_t, uint8_t): 447: verify failed, error = NRF_ERROR_NO_MEM
virtual err_t BLEService::begin(): 83: verify failed, error = BLE_ERROR_NOT_ENABLED
virtual err_t BLEDis::begin(): 114: verify failed, error = BLE_ERROR_NOT_ENABLED
bool BLEUuid::begin(): 147: verify failed, error = BLE_ERROR_NOT_ENABLED
virtual err_t BLEService::begin(): 83: verify failed, error = BLE_ERROR_NOT_ENABLED
virtual err_t BLEUart::begin(): 161: verify failed, error = BLE_ERROR_NOT_ENABLED
uint8_t AdafruitBluefruit::getName(char*, uint16_t): 531: verify failed, error = BLE_ERROR_NOT_ENABLED
bool BLEAdvertising::_start(uint16_t, uint16_t): 377: verify failed, error = BLE_ERROR_NOT_ENABLED
```