### PR TITLE
Add support for VDDHDIV5

### DIFF
--- a/cores/nRF5/wiring_analog.h
+++ b/cores/nRF5/wiring_analog.h
@@ -92,6 +92,14 @@ extern uint32_t analogRead( uint32_t ulPin ) ;
  */
 extern uint32_t analogReadVDD( void ) ;
 
+#ifdef SAADC_CH_PSELP_PSELP_VDDHDIV5
+/*
+ * \brief Read the value from the vddh pin with div5.
+ *
+ * \return Read value from vddh pin with div5, if no error.
+ */
+extern uint32_t analogReadVDDHDIV5( void ) ;
+#endif
 
 /*
  * \brief Set the resolution of analogRead return values. Default is 10 bits (range from 0 to 1023).

--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -284,6 +284,13 @@ uint32_t analogReadVDD( void )
   return analogRead_internal(SAADC_CH_PSELP_PSELP_VDD);
 }
 
+#ifdef SAADC_CH_PSELP_PSELP_VDDHDIV5
+uint32_t analogReadVDDHDIV5( void )
+{
+  return analogRead_internal(SAADC_CH_PSELP_PSELP_VDDHDIV5);
+}
+#endif
+
 void analogCalibrateOffset( void )
 {
   // Enable the SAADC


### PR DESCRIPTION
Allow reading the VDDHDIV5 ADC source on devices that support it, such as nRF52840. For designs where the VDDH pin is connected to a battery, this is a great way to measure battery voltage without any additional external components.