### PR TITLE
Fix memory leak on failure to open

### DIFF
--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -66,6 +66,8 @@ bool File::_open_file (char const *filepath, uint8_t mode)
     {
       // failed to open
       PRINT_LFS_ERR(rc);
+      // free memory
+      rtos_free(_file);
       return false;
     }
 
@@ -89,6 +91,8 @@ bool File::_open_dir (char const *filepath)
   {
     // failed to open
     PRINT_LFS_ERR(rc);
+    // free memory
+    rtos_free(_dir);
     return false;
   }
 

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -68,6 +68,7 @@ bool File::_open_file (char const *filepath, uint8_t mode)
       PRINT_LFS_ERR(rc);
       // free memory
       rtos_free(_file);
+      _file = NULL;
       return false;
     }
 
@@ -93,6 +94,7 @@ bool File::_open_dir (char const *filepath)
     PRINT_LFS_ERR(rc);
     // free memory
     rtos_free(_dir);
+    _dir = NULL;
     return false;
   }
 


### PR DESCRIPTION
Fixes leak of memory caused by failure to free file and directory structures when open fails.