### PR TITLE
Making new/delete operators overridable

### DIFF
--- a/cores/nRF5/new.cpp
+++ b/cores/nRF5/new.cpp
@@ -23,26 +23,32 @@
 #include <sys/stat.h>
 #include <malloc.h>
 
+__attribute__((weak))
 void *operator new(size_t size) {
   return rtos_malloc(size);
 }
 
+__attribute__((weak))
 void *operator new[](size_t size) {
   return rtos_malloc(size);
 }
 
+__attribute__((weak))
 void operator delete(void * ptr) {
   rtos_free(ptr);
 }
 
+__attribute__((weak))
 void operator delete[](void * ptr) {
   rtos_free(ptr);
 }
 
+__attribute__((weak))
 void operator delete(void * ptr, unsigned int) {
   rtos_free(ptr);
 }
 
+__attribute__((weak))
 void operator delete[](void * ptr, unsigned int) {
   rtos_free(ptr);
 }


### PR DESCRIPTION
Added `__attribute__((weak))` weak linking annotation to new and delete operator overrides to allow for user-defined overrides.