### PR TITLE
Null termination of file name when max length

### DIFF
--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS_File.cpp
@@ -37,6 +37,7 @@ File::File (Adafruit_LittleFS &fs)
   _fs = &fs;
   _is_dir = false;
   _name[0] = 0;
+  _name[LFS_NAME_MAX] = 0;
   _dir_path = NULL;
 
   _dir = NULL;


### PR DESCRIPTION
File names are returned unterminated in the edge case where their length is max size This is due to the fact that strncpy does terminate the destination string when the source string is greater than or equal to the specifid maximum length.