### PR TITLE
Added methods to query filesystem for size

### DIFF
--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
@@ -239,6 +239,32 @@ bool Adafruit_LittleFS::rmdir_r (char const *filepath)
   return LFS_ERR_OK == err;
 }
 
+static int _lfs_count(void *p, lfs_block_t block) {
+  *(size_t *)p += 1;
+	return 0;
+}
+
+size_t Adafruit_LittleFS::usedBlocks() {
+  _lockFS();
+
+  size_t blocks = 0;
+  lfs_traverse(&_lfs, _lfs_count, &blocks);
+
+  _unlockFS();
+  return blocks;
+}
+
+size_t Adafruit_LittleFS::usedBytes() {
+  if (nullptr == _lfs_cfg) return 0;
+	const size_t blocks_used = usedBlocks();
+	return _lfs_cfg->block_size * blocks_used;
+}
+
+size_t Adafruit_LittleFS::totalBytes() {
+  if (nullptr == _lfs_cfg) return 0;
+	return _lfs_cfg->block_size * _lfs_cfg->block_count;
+}
+
 //------------- Debug -------------//
 #if CFG_DEBUG
 

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.cpp
@@ -240,29 +240,31 @@ bool Adafruit_LittleFS::rmdir_r (char const *filepath)
 }
 
 static int _lfs_count(void *p, lfs_block_t block) {
+  (void) block;
   *(size_t *)p += 1;
-	return 0;
+  return 0;
 }
 
 size_t Adafruit_LittleFS::usedBlocks() {
   _lockFS();
 
-  size_t blocks = 0;
-  lfs_traverse(&_lfs, _lfs_count, &blocks);
+  size_t block_used = 0;
+  lfs_traverse(&_lfs, _lfs_count, &block_used);
 
   _unlockFS();
-  return blocks;
+  return block_used;
 }
 
 size_t Adafruit_LittleFS::usedBytes() {
-  if (nullptr == _lfs_cfg) return 0;
-	const size_t blocks_used = usedBlocks();
-	return _lfs_cfg->block_size * blocks_used;
+  if (nullptr == _lfs_cfg)
+    return 0;
+  return _lfs_cfg->block_size * usedBlocks();
 }
 
 size_t Adafruit_LittleFS::totalBytes() {
-  if (nullptr == _lfs_cfg) return 0;
-	return _lfs_cfg->block_size * _lfs_cfg->block_count;
+  if (nullptr == _lfs_cfg)
+    return 0;
+  return _lfs_cfg->block_size * _lfs_cfg->block_count;
 }
 
 //------------- Debug -------------//

--- a/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
+++ b/libraries/Adafruit_LittleFS/src/Adafruit_LittleFS.h
@@ -70,6 +70,10 @@ class Adafruit_LittleFS
     // format file system
     bool format (void);
 
+    size_t usedBlocks();
+    size_t usedBytes();
+    size_t totalBytes();
+
     /*------------------------------------------------------------------*/
     /* INTERNAL USAGE ONLY
      * Although declare as public, it is meant to be invoked by internal


### PR DESCRIPTION
Added methods totalBytes() and usedBytes() for obtaining flash filesystem overall size and available space, like those found in SPIFFS. Also added usedBlocks() method for good measure.