### PR TITLE
Fix a copy-paste error in the bug report template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a problem with TinyUSB Library
+description: Report a problem with the Adafruit nRF52 Arduino Core
 labels: 'Bug'
 body:
   - type: markdown


### PR DESCRIPTION
As I was about to file a bug, I noticed a typo, so figured it was worth sending a quick PR.