### PR TITLE
Adds feature reports support on Bluefruit52Lib's BLEHidGeneric service

### DIFF
--- a/libraries/Bluefruit52Lib/src/services/BLEHidGeneric.cpp
+++ b/libraries/Bluefruit52Lib/src/services/BLEHidGeneric.cpp
@@ -132,8 +132,7 @@ void BLEHidGeneric::setFeatureReportCallback(uint8_t reportID, BLECharacteristic
   // index is ID-1
   uint8_t const idx =  ( reportID ? (reportID - 1) : 0 );
 
-  // report mode
-  if (idx < _num_feature) _chr_features[idx].setWriteCallback(fp);
+  if ( idx < _num_feature ) _chr_features[idx].setWriteCallback(fp);
 }
 
 /*------------------------------------------------------------------*/
@@ -207,14 +206,14 @@ err_t BLEHidGeneric::begin(void)
   {
     _chr_features[i].setUuid(UUID16_CHR_REPORT);
     _chr_features[i].setProperties(CHR_PROPS_READ | CHR_PROPS_WRITE | CHR_PROPS_WRITE_WO_RESP);
-    _chr_features[i].setPermission(SECMODE_OPEN, SECMODE_OPEN);
+    _chr_features[i].setPermission(SECMODE_ENC_NO_MITM, SECMODE_ENC_NO_MITM);
     _chr_features[i].setReportRefDescriptor(i+1, REPORT_TYPE_FEATURE);
 
-    // Input report len is configured, else variable len up to 255
+    // Feature report len is configured, else variable len up to 255
     if ( _feature_len ) _chr_features[i].setFixedLen( _feature_len[i] );
 
-    VERIFY_STATUS(_chr_features[i].begin());
-    _chr_features[i].write8(0);                 //  default value
+    VERIFY_STATUS( _chr_features[i].begin() );
+    _chr_features[i].write8(0);
   }
 
   // Report Map (HID Report Descriptor)
@@ -309,9 +308,10 @@ bool BLEHidGeneric::bootMouseReport(void const* data, int len)
 
 bool BLEHidGeneric::featureReport(uint8_t reportID, void const* data, int len)
 {
-    uint8_t idx = reportID ? reportID - 1 : 0;
-    if (idx >= _num_feature) return false;
-    return _chr_features[idx].write((uint8_t const*) data, len);
+  // index is ID-1
+  uint8_t const idx = ( reportID ? (reportID - 1) : 0 );
+  if ( idx >= _num_feature ) return false;
+  return _chr_features[idx].write((uint8_t const*) data, len);
 }
 
 // Conversion table from Ascii to keycode (shift, keycode)

--- a/libraries/Bluefruit52Lib/src/services/BLEHidGeneric.h
+++ b/libraries/Bluefruit52Lib/src/services/BLEHidGeneric.h
@@ -63,12 +63,15 @@ class BLEHidGeneric : public BLEService
 
     void setOutputReportCallback(uint8_t reportID, BLECharacteristic::write_cb_t fp);
 
+    void setFeatureReportCallback(uint8_t reportID, BLECharacteristic::write_cb_t fp);
+
     virtual err_t begin(void);
 
     bool isBootMode(void) { return !_report_mode; }
 
     // Send Report to default connection
     bool inputReport(uint8_t reportID, void const* data, int len);
+    bool featureReport(uint8_t reportID, void const* data, int len);
     bool bootKeyboardReport(void const* data, int len);
     bool bootMouseReport(void const* data, int len);
 


### PR DESCRIPTION
BLE HID Input and output reports are working fine but support for feature reports is missing from this lib.

WebHID Explorer offers a great tool for testing feature reports. In order to get feature reports working with the Seeed XIAO nrf Sense board, I needed to patch these changes into the platform.io framework used.