### PR TITLE
make sure we don't keep the LED on when we autoConnLed(false)

### DIFF
--- a/libraries/Bluefruit52Lib/src/bluefruit.cpp
+++ b/libraries/Bluefruit52Lib/src/bluefruit.cpp
@@ -109,10 +109,10 @@ void adafruit_soc_task(void* arg);
 /*------------------------------------------------------------------*/
 /* INTERNAL FUNCTION
  *------------------------------------------------------------------*/
-static void bluefruit_blinky_cb( TimerHandle_t xTimer )
+void bluefruit_blinky_cb( TimerHandle_t xTimer )
 {
   (void) xTimer;
-  digitalToggle(LED_BLUE);
+  if ( Bluefruit._led_conn ) digitalToggle(LED_BLUE);
 }
 
 static void nrf_error_cb(uint32_t id, uint32_t pc, uint32_t info)

--- a/libraries/Bluefruit52Lib/src/bluefruit.h
+++ b/libraries/Bluefruit52Lib/src/bluefruit.h
@@ -256,6 +256,7 @@ class AdafruitBluefruit
     friend void SD_EVT_IRQHandler(void);
     friend void adafruit_ble_task(void* arg);
     friend void adafruit_soc_task(void* arg);
+    friend void bluefruit_blinky_cb(TimerHandle_t xTimer);
     friend class BLECentral;
 };
 


### PR DESCRIPTION
I was having trouble overriding the behavior of the `LED_BLUE` when setting `autoConnLed(false)`. It would still blink. The fix seems to be to check it in the `bluefruit_blinky_cb` callback.