### PR TITLE
fix: TWIM EasyDMA ordering and add writeThenRead() for atomic I2C transactions

### DIFF
--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -33,6 +33,7 @@
 class TwoWire : public Stream
 {
   public:
+    uint8_t writeThenRead(uint8_t address, const uint8_t *write_buffer, size_t write_len, uint8_t *read_buffer, size_t read_len);
     TwoWire(NRF_TWIM_Type * p_twim, NRF_TWIS_Type * p_twis, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL);
     void begin();
     void begin(uint8_t);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -32,9 +32,8 @@
 
 class TwoWire : public Stream
 {
-  public:
-    uint8_t writeThenRead(uint8_t address, const uint8_t *write_buffer, size_t write_len, uint8_t *read_buffer, size_t read_len);
-    TwoWire(NRF_TWIM_Type * p_twim, NRF_TWIS_Type * p_twis, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL);
+public:
+    TwoWire(NRF_TWIM_Type *p_twim, NRF_TWIS_Type *p_twis, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL);
     void begin();
     void begin(uint8_t);
     void end();
@@ -49,7 +48,35 @@ class TwoWire : public Stream
     uint8_t requestFrom(uint8_t address, size_t quantity);
 
     size_t write(uint8_t data);
-    size_t write(const uint8_t * data, size_t quantity);
+    size_t write(const uint8_t *data, size_t quantity);
+
+    // Performs one combined I2C write-then-read transaction:
+    //
+    //   START -> address+W -> [txBuffer] -> REPEATED START
+    //         -> address+R -> [rxBuffer] -> STOP
+    //
+    // txBuffer points to the bytes transmitted before the repeated START.
+    // txQuantity is the number of bytes to transmit from txBuffer.
+    //
+    // rxBuffer points to storage for bytes received after the repeated START.
+    // rxQuantity is the number of bytes to receive into rxBuffer.
+    //
+    // On NRF TWIM, this is hardware-sequenced using LASTTX_STARTRX, so the
+    // transition from TX to RX does not depend on CPU scheduling. This prevents
+    // SoftDevice/CPU preemption from splitting the write phase from the read
+    // phase.
+    // See:
+    //    - https://www.i2c-bus.org/repeated-start-condition/
+    //    - https://docs.nordicsemi.com/r/bundle/ps_nrf52832/page/twim.html
+    //
+    // Both buffers must be in RAM; EasyDMA cannot access flash.
+    // rxQuantity must not exceed 1023 because TWIM RXD.MAXCNT is 10-bit.
+    //
+    // Returns 0 on success, or Wire-compatible error codes:
+    //   2 = address NACK
+    //   3 = data NACK
+    //   4 = other errorf
+    uint8_t writeThenRead(uint8_t address, const uint8_t *txBuffer, size_t txQuantity, uint8_t *rxBuffer, size_t rxQuantity);
 
     virtual int available(void);
     virtual int read(void);

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -278,43 +278,36 @@ uint8_t TwoWire::endTransmission()
   return endTransmission(true);
 }
 
-// Combined write-then-read using TWIM hardware SHORTS.
+// NRF TWIM implementation note:
 //
-// Performs a single atomic I2C transaction:
-//   START → addr+W → [write_buffer] → REPEATED-START → addr+R → [read_buffer] → STOP
+// This uses LASTTX_STARTRX and LASTRX_STOP SHORTS so the TX->RX transition and
+// final STOP are hardware-sequenced. Once TASKS_STARTTX is triggered, EasyDMA
+// performs the full combined transaction without CPU intervention at the
+// repeated-start boundary.
 //
-// The LASTTX_STARTRX SHORT ensures the transition from TX to RX happens in
-// hardware without CPU involvement. EasyDMA completes the full sequence
-// autonomously, so SoftDevice preemption cannot cause partial transfers.
-//
-// Both buffers must be in RAM (EasyDMA cannot access flash).
-// read_len must not exceed 1023 (TWIM RXD.MAXCNT is 10-bit).
-//
-// Returns 0 on success, or Wire-compatible error codes (2=ANACK, 3=DNACK, 4=other).
-uint8_t TwoWire::writeThenRead(uint8_t address,
-                               const uint8_t *write_buffer, size_t write_len,
-                               uint8_t *read_buffer, size_t read_len)
+// Both txBuffer and rxBuffer must be in RAM; EasyDMA cannot access flash.
+// rxQuantity must not exceed 1023 because TWIM RXD.MAXCNT is 10-bit.
+uint8_t TwoWire::writeThenRead(uint8_t address, const uint8_t *txBuffer, size_t txQuantity, uint8_t *rxBuffer, size_t rxQuantity)
 {
-  if (write_len == 0 || read_len == 0)
+  if (txQuantity == 0 || rxQuantity == 0)
   {
     return 4;
   }
 
   _p_twim->ADDRESS = address;
 
-  _p_twim->TXD.PTR    = (uint32_t)write_buffer;
-  _p_twim->TXD.MAXCNT = write_len;
-  _p_twim->RXD.PTR    = (uint32_t)read_buffer;
-  _p_twim->RXD.MAXCNT = read_len;
+  _p_twim->TXD.PTR    = (uint32_t)txBuffer;
+  _p_twim->TXD.MAXCNT = txQuantity;
+  _p_twim->RXD.PTR    = (uint32_t)rxBuffer;
+  _p_twim->RXD.MAXCNT = rxQuantity;
 
-  _p_twim->SHORTS = TWIM_SHORTS_LASTTX_STARTRX_Msk |
-                     TWIM_SHORTS_LASTRX_STOP_Msk;
+  _p_twim->SHORTS = TWIM_SHORTS_LASTTX_STARTRX_Msk | TWIM_SHORTS_LASTRX_STOP_Msk;
 
   _p_twim->ERRORSRC       = 0xFFFFFFFFUL;
   _p_twim->EVENTS_STOPPED = 0x0UL;
   _p_twim->EVENTS_ERROR   = 0x0UL;
   __DMB();
-  _p_twim->TASKS_STARTTX  = 0x1UL;
+  _p_twim->TASKS_STARTTX = 0x1UL;
 
   uint32_t timeout = 1000000u;
   while (!_p_twim->EVENTS_STOPPED && !_p_twim->EVENTS_ERROR && --timeout);
@@ -325,11 +318,11 @@ uint8_t TwoWire::writeThenRead(uint8_t address,
   {
     _p_twim->EVENTS_ERROR = 0x0UL;
 
-    uint32_t error = _p_twim->ERRORSRC;
+    uint32_t error    = _p_twim->ERRORSRC;
     _p_twim->ERRORSRC = error;
 
     _p_twim->EVENTS_STOPPED = 0x0UL;
-    _p_twim->TASKS_STOP = 0x1UL;
+    _p_twim->TASKS_STOP     = 0x1UL;
     while (!_p_twim->EVENTS_STOPPED);
     _p_twim->EVENTS_STOPPED = 0x0UL;
 
@@ -341,7 +334,7 @@ uint8_t TwoWire::writeThenRead(uint8_t address,
 
   _p_twim->EVENTS_STOPPED = 0x0UL;
 
-  if (_p_twim->RXD.AMOUNT != read_len)
+  if (_p_twim->RXD.AMOUNT != rxQuantity)
   {
     return 4;
   }

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -278,6 +278,77 @@ uint8_t TwoWire::endTransmission()
   return endTransmission(true);
 }
 
+// Combined write-then-read using TWIM hardware SHORTS.
+//
+// Performs a single atomic I2C transaction:
+//   START → addr+W → [write_buffer] → REPEATED-START → addr+R → [read_buffer] → STOP
+//
+// The LASTTX_STARTRX SHORT ensures the transition from TX to RX happens in
+// hardware without CPU involvement. EasyDMA completes the full sequence
+// autonomously, so SoftDevice preemption cannot cause partial transfers.
+//
+// Both buffers must be in RAM (EasyDMA cannot access flash).
+// read_len must not exceed 1023 (TWIM RXD.MAXCNT is 10-bit).
+//
+// Returns 0 on success, or Wire-compatible error codes (2=ANACK, 3=DNACK, 4=other).
+uint8_t TwoWire::writeThenRead(uint8_t address,
+                               const uint8_t *write_buffer, size_t write_len,
+                               uint8_t *read_buffer, size_t read_len)
+{
+  if (write_len == 0 || read_len == 0)
+  {
+    return 4;
+  }
+
+  _p_twim->ADDRESS = address;
+
+  _p_twim->TXD.PTR    = (uint32_t)write_buffer;
+  _p_twim->TXD.MAXCNT = write_len;
+  _p_twim->RXD.PTR    = (uint32_t)read_buffer;
+  _p_twim->RXD.MAXCNT = read_len;
+
+  _p_twim->SHORTS = TWIM_SHORTS_LASTTX_STARTRX_Msk |
+                     TWIM_SHORTS_LASTRX_STOP_Msk;
+
+  _p_twim->ERRORSRC       = 0xFFFFFFFFUL;
+  _p_twim->EVENTS_STOPPED = 0x0UL;
+  _p_twim->EVENTS_ERROR   = 0x0UL;
+  __DMB();
+  _p_twim->TASKS_STARTTX  = 0x1UL;
+
+  uint32_t timeout = 1000000u;
+  while (!_p_twim->EVENTS_STOPPED && !_p_twim->EVENTS_ERROR && --timeout);
+
+  _p_twim->SHORTS = 0;
+
+  if (_p_twim->EVENTS_ERROR || timeout == 0)
+  {
+    _p_twim->EVENTS_ERROR = 0x0UL;
+
+    uint32_t error = _p_twim->ERRORSRC;
+    _p_twim->ERRORSRC = error;
+
+    _p_twim->EVENTS_STOPPED = 0x0UL;
+    _p_twim->TASKS_STOP = 0x1UL;
+    while (!_p_twim->EVENTS_STOPPED);
+    _p_twim->EVENTS_STOPPED = 0x0UL;
+
+    if (timeout == 0) return 4;
+    if (error == TWIM_ERRORSRC_ANACK_Msk) return 2;
+    if (error == TWIM_ERRORSRC_DNACK_Msk) return 3;
+    return 4;
+  }
+
+  _p_twim->EVENTS_STOPPED = 0x0UL;
+
+  if (_p_twim->RXD.AMOUNT != read_len)
+  {
+    return 4;
+  }
+
+  return 0;
+}
+
 size_t TwoWire::write(uint8_t ucData)
 {
   // No writing, without begun transmission or a full buffer

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -158,9 +158,10 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
 
   _p_twim->ADDRESS = address;
 
-  _p_twim->TASKS_RESUME = 0x1UL;
   _p_twim->RXD.PTR = (uint32_t)rxBuffer._aucBuffer;
   _p_twim->RXD.MAXCNT = quantity;
+  __DMB();
+  _p_twim->TASKS_RESUME = 0x1UL;
   _p_twim->TASKS_STARTRX = 0x1UL;
 
   while(!_p_twim->EVENTS_RXSTARTED && !_p_twim->EVENTS_ERROR);
@@ -213,18 +214,17 @@ void TwoWire::beginTransmission(uint8_t address) {
 //  4 : Other error
 uint8_t TwoWire::endTransmission(bool stopBit)
 {
-  transmissionBegun = false ;
+  transmissionBegun = false;
 
   // Start I2C transmission
   _p_twim->ADDRESS = txAddress;
 
+  _p_twim->TXD.PTR = (uint32_t)txBuffer._aucBuffer;
+  _p_twim->TXD.MAXCNT = txBuffer.available();
+  __DMB();
   // just in case twi is stopped by bus error such as secondary device reset/stalled without replying ACK/NACK
   _p_twim->EVENTS_STOPPED = 0x0UL;
   _p_twim->TASKS_RESUME = 0x1UL;
-
-  _p_twim->TXD.PTR = (uint32_t)txBuffer._aucBuffer;
-  _p_twim->TXD.MAXCNT = txBuffer.available();
-
   _p_twim->TASKS_STARTTX = 0x1UL;
 
   while(!_p_twim->EVENTS_TXSTARTED && !_p_twim->EVENTS_ERROR);


### PR DESCRIPTION
### Summary

- Fix EasyDMA register ordering in `requestFrom()` and `endTransmission()`: DMA pointers (`RXD.PTR`/`MAXCNT`, `TXD.PTR`/`MAXCNT`) are now configured *before* triggering `TASKS_RESUME`, and a `__DMB()` barrier prevents the ARM write buffer from reordering the stores past the task trigger.
                                                                                   
- Add `writeThenRead()` — combined write-then-read that uses TWIM hardware SHORTS (`LASTTX_STARTRX` + `LASTRX_STOP`) to perform the full `START → W → REPEATED-START → R → STOP` sequence in EasyDMA without CPU involvement at the repeated-start boundary. This eliminates the START-STOP-START problem that occurs when SoftDevice or CPU preemption interrupts the software-mediated transition between `endTransmission(false)` and `requestFrom()`.

### Context
**Board: Seeed studio xiao sense ble nrf52840**
In our application we would see corrupted readings form a peripheral sitting on an I2C bus when we would enable BLE connections. The peripheral (LSM6DS3) has an internal pointer which is self updated to stream 6 channel of data to a single 2 byte buffer (so, 12 bytes for the whole 6 channels). Our firmware would repeatedly issue reads form that register (we exploited its FIFO) and keep track of how many bytes were read to correctly reconstruct the 6 signals (since only 2 bytes at time are available in the register).
The corruption would be a circular shift in the data of the signals: at some point, signal 1 would be stitched to signal 2 and so on as a circular shift. So, we missed 2 bytes and the whole data sequence would be offset.

### Debug
We checked our firmware up to reaching the single atomic I2C read. The shift would be due to a "missing" read which resulted in the cpu pointer being stale while the peripheral pointer would advance, since it had already issued the bytes to its register. This is the shift introduction.
We noted that the nrf52840 has an abstraction for the BLE stack (SoftDevice) which has the highest interrupt preemption priority, so its routine is serviced immediately. We thought that our heavy use of BLE radio in our firmware would eventually preempt the cpu while an I2C was issued and that servicing the routine would broke that read.
But the nrf52840 also have a DMA (EasyDMA), so why our cpu preemption was a problem in the first place?

### Findings
The current implementation of Wire.h for the nrf52840 does not use TWIM hardware SHORTS for repeated-START transactions, so the CPU must manually bridge the TX→RX transition each time. Enabling the SoftDevice stack installs high-priority interrupts that can preempt at any point, including between the TX and RX phases of a write-then-read I2C transaction. So, the preemption would eventually happens while the cpu would need to issue a START, but this breaks due to the BLE routine.

### Solution
The EasyDMA in the nrf52840 allows for repeated START-STOP so to not involve the cpu at all. We implemented `writeThenRead()` in this fix to do that.

### Tests

- [x] verified `writeThenRead()` with a sensor that requires repeated START (IMU LSM6DS3)
- [x] standard `beginTransmission()`/`endTransmission()`/`requestFrom()` flow still works                                                 
- [x] stress-test with BLE active confirm no START-STOP-START regression

Open to feedback on the API design, naming conventions, error handling approach or else. 