### PR TITLE
Wire (nRF52): add timeout to endTransmission()/requestFrom() poll loops

### DIFF
--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -31,6 +31,14 @@ extern "C" {
 
 #include <Adafruit_TinyUSB.h> // for Serial
 
+// Guards against a permanent MCU hang in the EVENTS_* poll loops below: on some
+// boards, probing an I2C address with nothing attached (or without pull-ups)
+// can leave the TWIM peripheral never raising the expected event or EVENTS_ERROR,
+// so an unbounded while(!event) spins forever. See adafruit/Adafruit_nRF52_Arduino#771.
+#ifndef I2C_TWIM_TIMEOUT_MS
+#define I2C_TWIM_TIMEOUT_MS 100
+#endif
+
 static volatile uint32_t* pincfg_reg(uint32_t pin)
 {
   NRF_GPIO_Type * port = nrf_gpio_pin_port_decode(&pin);
@@ -163,28 +171,49 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
   _p_twim->RXD.MAXCNT = quantity;
   _p_twim->TASKS_STARTRX = 0x1UL;
 
-  while(!_p_twim->EVENTS_RXSTARTED && !_p_twim->EVENTS_ERROR);
+  bool timed_out = false;
+  uint32_t wait_start = millis();
+  while(!_p_twim->EVENTS_RXSTARTED && !_p_twim->EVENTS_ERROR) {
+    if (millis() - wait_start > I2C_TWIM_TIMEOUT_MS) { timed_out = true; break; }
+  }
   _p_twim->EVENTS_RXSTARTED = 0x0UL;
 
-  while(!_p_twim->EVENTS_LASTRX && !_p_twim->EVENTS_ERROR);
+  if (!timed_out) {
+    wait_start = millis();
+    while(!_p_twim->EVENTS_LASTRX && !_p_twim->EVENTS_ERROR) {
+      if (millis() - wait_start > I2C_TWIM_TIMEOUT_MS) { timed_out = true; break; }
+    }
+  }
   _p_twim->EVENTS_LASTRX = 0x0UL;
 
-  if (stopBit || _p_twim->EVENTS_ERROR)
+  if (stopBit || _p_twim->EVENTS_ERROR || timed_out)
   {
     _p_twim->TASKS_STOP = 0x1UL;
-    while(!_p_twim->EVENTS_STOPPED);
+    wait_start = millis();
+    while(!_p_twim->EVENTS_STOPPED) {
+      if (millis() - wait_start > I2C_TWIM_TIMEOUT_MS) break;
+    }
     _p_twim->EVENTS_STOPPED = 0x0UL;
   }
   else
   {
     _p_twim->TASKS_SUSPEND = 0x1UL;
-    while(!_p_twim->EVENTS_SUSPENDED);
+    wait_start = millis();
+    while(!_p_twim->EVENTS_SUSPENDED) {
+      if (millis() - wait_start > I2C_TWIM_TIMEOUT_MS) break;
+    }
     _p_twim->EVENTS_SUSPENDED = 0x0UL;
   }
 
   if (_p_twim->EVENTS_ERROR)
   {
     _p_twim->EVENTS_ERROR = 0x0UL;
+  }
+
+  // on timeout nothing was actually clocked in - report 0 bytes rather than
+  // whatever stale RXD.AMOUNT is left over from a previous transaction
+  if (timed_out) {
+    return 0;
   }
 
   byteRead = rxBuffer._iHead = _p_twim->RXD.AMOUNT;
@@ -227,24 +256,37 @@ uint8_t TwoWire::endTransmission(bool stopBit)
 
   _p_twim->TASKS_STARTTX = 0x1UL;
 
-  while(!_p_twim->EVENTS_TXSTARTED && !_p_twim->EVENTS_ERROR);
+  bool timed_out = false;
+  uint32_t wait_start = millis();
+  while(!_p_twim->EVENTS_TXSTARTED && !_p_twim->EVENTS_ERROR) {
+    if (millis() - wait_start > I2C_TWIM_TIMEOUT_MS) { timed_out = true; break; }
+  }
   _p_twim->EVENTS_TXSTARTED = 0x0UL;
 
-  if (txBuffer.available()) {
-    while(!_p_twim->EVENTS_LASTTX && !_p_twim->EVENTS_ERROR);
+  if (!timed_out && txBuffer.available()) {
+    wait_start = millis();
+    while(!_p_twim->EVENTS_LASTTX && !_p_twim->EVENTS_ERROR) {
+      if (millis() - wait_start > I2C_TWIM_TIMEOUT_MS) { timed_out = true; break; }
+    }
   }
   _p_twim->EVENTS_LASTTX = 0x0UL;
 
-  if (stopBit || _p_twim->EVENTS_ERROR)
+  if (stopBit || _p_twim->EVENTS_ERROR || timed_out)
   {
     _p_twim->TASKS_STOP = 0x1UL;
-    while(!_p_twim->EVENTS_STOPPED);
+    wait_start = millis();
+    while(!_p_twim->EVENTS_STOPPED) {
+      if (millis() - wait_start > I2C_TWIM_TIMEOUT_MS) break;
+    }
     _p_twim->EVENTS_STOPPED = 0x0UL;
   }
   else
   {
     _p_twim->TASKS_SUSPEND = 0x1UL;
-    while(!_p_twim->EVENTS_SUSPENDED);
+    wait_start = millis();
+    while(!_p_twim->EVENTS_SUSPENDED) {
+      if (millis() - wait_start > I2C_TWIM_TIMEOUT_MS) break;
+    }
     _p_twim->EVENTS_SUSPENDED = 0x0UL;
   }
 
@@ -268,6 +310,14 @@ uint8_t TwoWire::endTransmission(bool stopBit)
     {
       return 4;
     }
+  }
+
+  // hardware never raised EVENTS_ERROR but also never completed the transaction -
+  // report it as a failure so callers (e.g. an I2C bus scan) don't mistake a dead
+  // bus for a device that ACKed. See adafruit/Adafruit_nRF52_Arduino#771.
+  if (timed_out)
+  {
+    return 4;
   }
 
   return 0;


### PR DESCRIPTION
## Summary

Fixes #771 (root cause was already correctly identified there by @apoorv1in). `TwoWire::endTransmission()` and `TwoWire::requestFrom()` in `libraries/Wire/Wire_nRF52.cpp` both spin on unbounded `while(!EVENT)` loops waiting on the TWIM peripheral. Several of these - notably the `EVENTS_STOPPED` wait in both functions - have no `EVENTS_ERROR` escape at all, so if the hardware never raises the expected event, the call never returns and the whole single-threaded firmware hangs forever.

This isn't only a mid-transaction problem (as in #771). It also bites any board that probes for an optional/absent I2C device during boot, before anything else has initialized - I hit it via [MeshCore](https://github.com/meshcore-dev/MeshCore)'s `Xiao_nrf52` target, which runs an RTC autodiscovery scan (4 hardcoded chip addresses) in `radio_init()`. On a Xiao nRF52840 + Wio-SX1262 with no RTC actually wired up, that scan hangs the device on every single cold boot - no serial output, no BLE advertising, nothing (see [meshcore-dev/MeshCore#2068](https://github.com/meshcore-dev/MeshCore/issues/2068), reported across firmware versions v1.10.0 through current).

## Change

Adds a bounded `I2C_TWIM_TIMEOUT_MS` (default 100ms, `#define`-overridable) to every wait loop in both `endTransmission()` and `requestFrom()`. Important detail: a timeout that occurs before the hardware transaction actually completed is surfaced as a proper error return (`endTransmission`: `4` / "other error"; `requestFrom`: `0` bytes read) rather than silently falling through to the existing success path - if a caller treats "no error raised" as "device found" (as an I2C bus-scan probe typically does), a timeout that's misreported as success would be a false-positive device detection, which is worse than the original hang.

## Testing

Tested on a Seeed XIAO nRF52840 + Wio-SX1262 board that reliably hung at boot via MeshCore's RTC autodiscovery probe, on every power cycle, prior to this patch. With this patch:
- The probe now completes (via timeout) instead of hanging - board boots and responds over serial/BLE normally.
- I also tested restoring MeshCore's RTC/sensor probing (rather than skipping it) with only this driver patch applied, no other workaround: the board reliably boots to a fully functional state, just with roughly a minute of added boot latency from timing out on ~15 absent I2C addresses (4 RTC chips + several environment sensor probes) - a real but bounded and expected cost given nothing is attached, versus the prior unbounded hang.

Happy to adjust the default timeout value or restructure the loops differently if you'd prefer a different shape for this fix.
