### PR TITLE
Add non-blocking timeout option to `getHvnPacket()` / `notify()`

### DIFF
--- a/.github/workflows/platformio-package-ci.yml
+++ b/.github/workflows/platformio-package-ci.yml
@@ -1,0 +1,84 @@
+name: PlatformIO Package CI
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      base_version:
+        description: Base package version in MAJOR.MINOR form
+        required: false
+        default: "1.107"
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    env:
+      DEFAULT_BASE_VERSION: "1.107"
+      CI_RELEASE_TAG: dev
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Compute package version
+      id: version
+      env:
+        INPUT_BASE_VERSION: ${{ inputs.base_version }}
+      run: |
+        base_version="${INPUT_BASE_VERSION:-${DEFAULT_BASE_VERSION}}"
+        package_version="$(bash tools/compute-platformio-package-version.sh "${base_version}" "${GITHUB_RUN_NUMBER}")"
+        short_sha="$(git rev-parse --short=12 HEAD)"
+
+        echo "base_version=${base_version}" >> "${GITHUB_OUTPUT}"
+        echo "package_version=${package_version}" >> "${GITHUB_OUTPUT}"
+        echo "short_sha=${short_sha}" >> "${GITHUB_OUTPUT}"
+
+    - name: Build PlatformIO package
+      run: bash tools/build-platformio-package.sh "${{ steps.version.outputs.package_version }}"
+
+    - name: Upload workflow artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: framework-arduinoadafruitnrf52-${{ steps.version.outputs.package_version }}-${{ steps.version.outputs.short_sha }}
+        path: dist/framework-arduinoadafruitnrf52.tar.bz2
+        if-no-files-found: error
+
+    - name: Publish rolling CI release asset
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ env.CI_RELEASE_TAG }}
+        PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
+        SHORT_SHA: ${{ steps.version.outputs.short_sha }}
+      run: |
+        cat > release-notes.txt <<EOF
+        Rolling CI package for framework-arduinoadafruitnrf52
+
+        Package version: ${PACKAGE_VERSION}
+        Source commit: ${GITHUB_SHA}
+        Short commit: ${SHORT_SHA}
+        Workflow run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+        EOF
+
+        if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+          gh release upload "${RELEASE_TAG}" dist/framework-arduinoadafruitnrf52.tar.bz2 --clobber
+          gh release edit "${RELEASE_TAG}" \
+            --title "${RELEASE_TAG}" \
+            --notes-file release-notes.txt \
+            --prerelease
+        else
+          gh release create "${RELEASE_TAG}" \
+            dist/framework-arduinoadafruitnrf52.tar.bz2 \
+            --target "${GITHUB_SHA}" \
+            --title "${RELEASE_TAG}" \
+            --notes-file release-notes.txt \
+            --prerelease
+        fi

--- a/.github/workflows/platformio-package-release.yml
+++ b/.github/workflows/platformio-package-release.yml
@@ -1,0 +1,45 @@
+name: PlatformIO Package Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Package version without the leading v
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: recursive
+
+    - name: Build PlatformIO package
+      run: bash tools/build-platformio-package.sh "${{ inputs.version }}"
+
+    - name: Publish GitHub release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PACKAGE_VERSION: ${{ inputs.version }}
+        RELEASE_TAG: v${{ inputs.version }}
+      run: |
+        cat > release-notes.txt <<EOF
+        PlatformIO package release for framework-arduinoadafruitnrf52
+
+        Package version: ${PACKAGE_VERSION}
+        Source commit: ${GITHUB_SHA}
+        EOF
+
+        gh release create "${RELEASE_TAG}" \
+          "dist/framework-arduinoadafruitnrf52.tar.bz2" \
+          --target "${GITHUB_SHA}" \
+          --title "${RELEASE_TAG}" \
+          --notes-file release-notes.txt

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 /boards.local.txt
 /platform.local.txt
 
+.codex
+
+dist/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,32 @@ Following boards are also included but are not officially supported:
 - [Nordic nRF52840DK PCA10056](https://www.nordicsemi.com/Software-and-Tools/Development-Kits/nRF52840-DK)
 - [Particle Xenon](https://store.particle.io/products/xenon)
 
+## PlatformIO Package Releases
+
+This fork can publish a PlatformIO framework package tarball named `framework-arduinoadafruitnrf52` from GitHub Releases.
+
+Consumer projects can override the framework selected by a PlatformIO platform, such as Seeed's `platform-seeedboards`, by pinning the release asset directly:
+
+```ini
+platform_packages =
+  framework-arduinoadafruitnrf52 @ https://github.com/stealth30110/Adafruit_nRF52_Arduino/releases/download/vX.Y.Z/framework-arduinoadafruitnrf52.tar.bz2
+```
+
+Notes:
+
+- This replaces local edits under `.pio-core/packages/...` with a versioned release artifact.
+- Consumers should pin an explicit release version for reproducible builds.
+- Publish this fork with a version higher than the currently published PlatformIO package lineage. As of 2026-04-30, `framework-arduinoadafruitnrf52` is at `1.107`, so this fork should start at `1.107.1` or above.
+- The release tarball is built by the `PlatformIO Package Release` GitHub Actions workflow in this repository.
+
+For commit-driven integration builds, the `PlatformIO Package CI` workflow runs on each push to `main`, computes a package version as `<base-version>.<github-run-number>`, uploads the tarball as a workflow artifact, and refreshes a rolling prerelease asset at:
+
+```text
+https://github.com/stealth30110/Adafruit_nRF52_Arduino/releases/download/dev/framework-arduinoadafruitnrf52.tar.bz2
+```
+
+That rolling URL is convenient for testing, but consumers that need reproducible builds should still pin an explicit versioned release instead of `dev`.
+
 ## BSP Installation
 
 There are two methods that you can use to install this BSP. We highly recommend the first option unless you wish to participate in active development of this codebase via Github.

--- a/cores/nRF5/linker/nrf52840_s140_v7.ld
+++ b/cores/nRF5/linker/nrf52840_s140_v7.ld
@@ -1,0 +1,38 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx)     : ORIGIN = 0x27000, LENGTH = 0xED000 - 0x27000
+
+  /* SRAM required by Softdevice depend on
+   * - Attribute Table Size (Number of Services and Characteristics)
+   * - Vendor UUID count
+   * - Max ATT MTU
+   * - Concurrent connection peripheral + central + secure links
+   * - Event Len, HVN queue, Write CMD queue
+   */
+  RAM (rwx) :  ORIGIN = 0x20006000, LENGTH = 0x20040000 - 0x20006000
+}
+
+SECTIONS
+{
+  . = ALIGN(4);
+  .svc_data :
+  {
+    PROVIDE(__start_svc_data = .);
+    KEEP(*(.svc_data))
+    PROVIDE(__stop_svc_data = .);
+  } > RAM
+
+  .fs_data :
+  {
+    PROVIDE(__start_fs_data = .);
+    KEEP(*(.fs_data))
+    PROVIDE(__stop_fs_data = .);
+  } > RAM
+} INSERT AFTER .data;
+
+INCLUDE "nrf52_common.ld"

--- a/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
+++ b/libraries/Bluefruit52Lib/src/BLECharacteristic.cpp
@@ -704,7 +704,7 @@ bool BLECharacteristic::notifyEnabled(uint16_t conn_hdl)
   return  (getCccd(conn_hdl) & BLE_GATT_HVX_NOTIFICATION);
 }
 
-bool BLECharacteristic::notify(uint16_t conn_hdl, const void* data, uint16_t len)
+bool BLECharacteristic::notify(uint16_t conn_hdl, const void* data, uint16_t len, uint32_t hvn_timeout_ms)
 {
   VERIFY( _properties.notify );
 
@@ -725,7 +725,7 @@ bool BLECharacteristic::notify(uint16_t conn_hdl, const void* data, uint16_t len
     while ( remaining )
     {
       // Failed if there is no free buffer
-      if ( !conn->getHvnPacket() ) return false;
+      if ( !conn->getHvnPacket(hvn_timeout_ms) ) return false;
 
       uint16_t packet_len = min16(max_payload, remaining);
 

--- a/libraries/Bluefruit52Lib/src/BLECharacteristic.h
+++ b/libraries/Bluefruit52Lib/src/BLECharacteristic.h
@@ -153,7 +153,7 @@ class BLECharacteristic
 
     /*------------- Notify multiple connections -------------*/
 //    bool notify   (uint16_t conn_hdl);
-    bool notify   (uint16_t conn_hdl, const void* data, uint16_t len);
+    bool notify   (uint16_t conn_hdl, const void* data, uint16_t len, uint32_t hvn_timeout_ms = BLE_GENERIC_TIMEOUT);
     bool notify   (uint16_t conn_hdl, const char* str);
 
     bool notify8  (uint16_t conn_hdl, uint8_t  num);

--- a/libraries/Bluefruit52Lib/src/BLEConnection.cpp
+++ b/libraries/Bluefruit52Lib/src/BLEConnection.cpp
@@ -229,9 +229,9 @@ void BLEConnection::stopRssi(void)
   sd_ble_gap_rssi_stop(_conn_hdl);
 }
 
-bool BLEConnection::getHvnPacket (void)
+bool BLEConnection::getHvnPacket (uint32_t timeout_ms)
 {
-  return xSemaphoreTake(_hvn_sem, ms2tick(BLE_GENERIC_TIMEOUT));
+  return xSemaphoreTake(_hvn_sem, ms2tick(timeout_ms));
 }
 
 bool BLEConnection::releaseHvnPacket(void)

--- a/libraries/Bluefruit52Lib/src/BLEConnection.h
+++ b/libraries/Bluefruit52Lib/src/BLEConnection.h
@@ -107,7 +107,7 @@ class BLEConnection
     int8_t getRssi(void);
     void stopRssi(void);
 
-    bool getHvnPacket(void);
+    bool getHvnPacket(uint32_t timeout_ms = BLE_GENERIC_TIMEOUT);
     bool releaseHvnPacket(void);
     bool getWriteCmdPacket(void);
     bool prepareForIndicateConfirm(void);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -33,6 +33,7 @@
 class TwoWire : public Stream
 {
   public:
+    uint8_t writeThenRead(uint8_t address, const uint8_t *write_buffer, size_t write_len, uint8_t *read_buffer, size_t read_len);
     TwoWire(NRF_TWIM_Type * p_twim, NRF_TWIS_Type * p_twis, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL);
     void begin();
     void begin(uint8_t);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -32,9 +32,8 @@
 
 class TwoWire : public Stream
 {
-  public:
-    uint8_t writeThenRead(uint8_t address, const uint8_t *write_buffer, size_t write_len, uint8_t *read_buffer, size_t read_len);
-    TwoWire(NRF_TWIM_Type * p_twim, NRF_TWIS_Type * p_twis, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL);
+public:
+    TwoWire(NRF_TWIM_Type *p_twim, NRF_TWIS_Type *p_twis, IRQn_Type IRQn, uint8_t pinSDA, uint8_t pinSCL);
     void begin();
     void begin(uint8_t);
     void end();
@@ -49,7 +48,35 @@ class TwoWire : public Stream
     uint8_t requestFrom(uint8_t address, size_t quantity);
 
     size_t write(uint8_t data);
-    size_t write(const uint8_t * data, size_t quantity);
+    size_t write(const uint8_t *data, size_t quantity);
+
+    // Performs one combined I2C write-then-read transaction:
+    //
+    //   START -> address+W -> [txBuffer] -> REPEATED START
+    //         -> address+R -> [rxBuffer] -> STOP
+    //
+    // txBuffer points to the bytes transmitted before the repeated START.
+    // txQuantity is the number of bytes to transmit from txBuffer.
+    //
+    // rxBuffer points to storage for bytes received after the repeated START.
+    // rxQuantity is the number of bytes to receive into rxBuffer.
+    //
+    // On NRF TWIM, this is hardware-sequenced using LASTTX_STARTRX, so the
+    // transition from TX to RX does not depend on CPU scheduling. This prevents
+    // SoftDevice/CPU preemption from splitting the write phase from the read
+    // phase.
+    // See:
+    //    - https://www.i2c-bus.org/repeated-start-condition/
+    //    - https://docs.nordicsemi.com/r/bundle/ps_nrf52832/page/twim.html
+    //
+    // Both buffers must be in RAM; EasyDMA cannot access flash.
+    // rxQuantity must not exceed 1023 because TWIM RXD.MAXCNT is 10-bit.
+    //
+    // Returns 0 on success, or Wire-compatible error codes:
+    //   2 = address NACK
+    //   3 = data NACK
+    //   4 = other errorf
+    uint8_t writeThenRead(uint8_t address, const uint8_t *txBuffer, size_t txQuantity, uint8_t *rxBuffer, size_t rxQuantity);
 
     virtual int available(void);
     virtual int read(void);

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -278,43 +278,36 @@ uint8_t TwoWire::endTransmission()
   return endTransmission(true);
 }
 
-// Combined write-then-read using TWIM hardware SHORTS.
+// NRF TWIM implementation note:
 //
-// Performs a single atomic I2C transaction:
-//   START → addr+W → [write_buffer] → REPEATED-START → addr+R → [read_buffer] → STOP
+// This uses LASTTX_STARTRX and LASTRX_STOP SHORTS so the TX->RX transition and
+// final STOP are hardware-sequenced. Once TASKS_STARTTX is triggered, EasyDMA
+// performs the full combined transaction without CPU intervention at the
+// repeated-start boundary.
 //
-// The LASTTX_STARTRX SHORT ensures the transition from TX to RX happens in
-// hardware without CPU involvement. EasyDMA completes the full sequence
-// autonomously, so SoftDevice preemption cannot cause partial transfers.
-//
-// Both buffers must be in RAM (EasyDMA cannot access flash).
-// read_len must not exceed 1023 (TWIM RXD.MAXCNT is 10-bit).
-//
-// Returns 0 on success, or Wire-compatible error codes (2=ANACK, 3=DNACK, 4=other).
-uint8_t TwoWire::writeThenRead(uint8_t address,
-                               const uint8_t *write_buffer, size_t write_len,
-                               uint8_t *read_buffer, size_t read_len)
+// Both txBuffer and rxBuffer must be in RAM; EasyDMA cannot access flash.
+// rxQuantity must not exceed 1023 because TWIM RXD.MAXCNT is 10-bit.
+uint8_t TwoWire::writeThenRead(uint8_t address, const uint8_t *txBuffer, size_t txQuantity, uint8_t *rxBuffer, size_t rxQuantity)
 {
-  if (write_len == 0 || read_len == 0)
+  if (txQuantity == 0 || rxQuantity == 0)
   {
     return 4;
   }
 
   _p_twim->ADDRESS = address;
 
-  _p_twim->TXD.PTR    = (uint32_t)write_buffer;
-  _p_twim->TXD.MAXCNT = write_len;
-  _p_twim->RXD.PTR    = (uint32_t)read_buffer;
-  _p_twim->RXD.MAXCNT = read_len;
+  _p_twim->TXD.PTR    = (uint32_t)txBuffer;
+  _p_twim->TXD.MAXCNT = txQuantity;
+  _p_twim->RXD.PTR    = (uint32_t)rxBuffer;
+  _p_twim->RXD.MAXCNT = rxQuantity;
 
-  _p_twim->SHORTS = TWIM_SHORTS_LASTTX_STARTRX_Msk |
-                     TWIM_SHORTS_LASTRX_STOP_Msk;
+  _p_twim->SHORTS = TWIM_SHORTS_LASTTX_STARTRX_Msk | TWIM_SHORTS_LASTRX_STOP_Msk;
 
   _p_twim->ERRORSRC       = 0xFFFFFFFFUL;
   _p_twim->EVENTS_STOPPED = 0x0UL;
   _p_twim->EVENTS_ERROR   = 0x0UL;
   __DMB();
-  _p_twim->TASKS_STARTTX  = 0x1UL;
+  _p_twim->TASKS_STARTTX = 0x1UL;
 
   uint32_t timeout = 1000000u;
   while (!_p_twim->EVENTS_STOPPED && !_p_twim->EVENTS_ERROR && --timeout);
@@ -325,11 +318,11 @@ uint8_t TwoWire::writeThenRead(uint8_t address,
   {
     _p_twim->EVENTS_ERROR = 0x0UL;
 
-    uint32_t error = _p_twim->ERRORSRC;
+    uint32_t error    = _p_twim->ERRORSRC;
     _p_twim->ERRORSRC = error;
 
     _p_twim->EVENTS_STOPPED = 0x0UL;
-    _p_twim->TASKS_STOP = 0x1UL;
+    _p_twim->TASKS_STOP     = 0x1UL;
     while (!_p_twim->EVENTS_STOPPED);
     _p_twim->EVENTS_STOPPED = 0x0UL;
 
@@ -341,7 +334,7 @@ uint8_t TwoWire::writeThenRead(uint8_t address,
 
   _p_twim->EVENTS_STOPPED = 0x0UL;
 
-  if (_p_twim->RXD.AMOUNT != read_len)
+  if (_p_twim->RXD.AMOUNT != rxQuantity)
   {
     return 4;
   }

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -278,6 +278,77 @@ uint8_t TwoWire::endTransmission()
   return endTransmission(true);
 }
 
+// Combined write-then-read using TWIM hardware SHORTS.
+//
+// Performs a single atomic I2C transaction:
+//   START → addr+W → [write_buffer] → REPEATED-START → addr+R → [read_buffer] → STOP
+//
+// The LASTTX_STARTRX SHORT ensures the transition from TX to RX happens in
+// hardware without CPU involvement. EasyDMA completes the full sequence
+// autonomously, so SoftDevice preemption cannot cause partial transfers.
+//
+// Both buffers must be in RAM (EasyDMA cannot access flash).
+// read_len must not exceed 1023 (TWIM RXD.MAXCNT is 10-bit).
+//
+// Returns 0 on success, or Wire-compatible error codes (2=ANACK, 3=DNACK, 4=other).
+uint8_t TwoWire::writeThenRead(uint8_t address,
+                               const uint8_t *write_buffer, size_t write_len,
+                               uint8_t *read_buffer, size_t read_len)
+{
+  if (write_len == 0 || read_len == 0)
+  {
+    return 4;
+  }
+
+  _p_twim->ADDRESS = address;
+
+  _p_twim->TXD.PTR    = (uint32_t)write_buffer;
+  _p_twim->TXD.MAXCNT = write_len;
+  _p_twim->RXD.PTR    = (uint32_t)read_buffer;
+  _p_twim->RXD.MAXCNT = read_len;
+
+  _p_twim->SHORTS = TWIM_SHORTS_LASTTX_STARTRX_Msk |
+                     TWIM_SHORTS_LASTRX_STOP_Msk;
+
+  _p_twim->ERRORSRC       = 0xFFFFFFFFUL;
+  _p_twim->EVENTS_STOPPED = 0x0UL;
+  _p_twim->EVENTS_ERROR   = 0x0UL;
+  __DMB();
+  _p_twim->TASKS_STARTTX  = 0x1UL;
+
+  uint32_t timeout = 1000000u;
+  while (!_p_twim->EVENTS_STOPPED && !_p_twim->EVENTS_ERROR && --timeout);
+
+  _p_twim->SHORTS = 0;
+
+  if (_p_twim->EVENTS_ERROR || timeout == 0)
+  {
+    _p_twim->EVENTS_ERROR = 0x0UL;
+
+    uint32_t error = _p_twim->ERRORSRC;
+    _p_twim->ERRORSRC = error;
+
+    _p_twim->EVENTS_STOPPED = 0x0UL;
+    _p_twim->TASKS_STOP = 0x1UL;
+    while (!_p_twim->EVENTS_STOPPED);
+    _p_twim->EVENTS_STOPPED = 0x0UL;
+
+    if (timeout == 0) return 4;
+    if (error == TWIM_ERRORSRC_ANACK_Msk) return 2;
+    if (error == TWIM_ERRORSRC_DNACK_Msk) return 3;
+    return 4;
+  }
+
+  _p_twim->EVENTS_STOPPED = 0x0UL;
+
+  if (_p_twim->RXD.AMOUNT != read_len)
+  {
+    return 4;
+  }
+
+  return 0;
+}
+
 size_t TwoWire::write(uint8_t ucData)
 {
   // No writing, without begun transmission or a full buffer

--- a/libraries/Wire/Wire_nRF52.cpp
+++ b/libraries/Wire/Wire_nRF52.cpp
@@ -158,9 +158,10 @@ uint8_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit)
 
   _p_twim->ADDRESS = address;
 
-  _p_twim->TASKS_RESUME = 0x1UL;
   _p_twim->RXD.PTR = (uint32_t)rxBuffer._aucBuffer;
   _p_twim->RXD.MAXCNT = quantity;
+  __DMB();
+  _p_twim->TASKS_RESUME = 0x1UL;
   _p_twim->TASKS_STARTRX = 0x1UL;
 
   while(!_p_twim->EVENTS_RXSTARTED && !_p_twim->EVENTS_ERROR);
@@ -213,18 +214,17 @@ void TwoWire::beginTransmission(uint8_t address) {
 //  4 : Other error
 uint8_t TwoWire::endTransmission(bool stopBit)
 {
-  transmissionBegun = false ;
+  transmissionBegun = false;
 
   // Start I2C transmission
   _p_twim->ADDRESS = txAddress;
 
+  _p_twim->TXD.PTR = (uint32_t)txBuffer._aucBuffer;
+  _p_twim->TXD.MAXCNT = txBuffer.available();
+  __DMB();
   // just in case twi is stopped by bus error such as secondary device reset/stalled without replying ACK/NACK
   _p_twim->EVENTS_STOPPED = 0x0UL;
   _p_twim->TASKS_RESUME = 0x1UL;
-
-  _p_twim->TXD.PTR = (uint32_t)txBuffer._aucBuffer;
-  _p_twim->TXD.MAXCNT = txBuffer.available();
-
   _p_twim->TASKS_STARTTX = 0x1UL;
 
   while(!_p_twim->EVENTS_TXSTARTED && !_p_twim->EVENTS_ERROR);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "framework-arduinoadafruitnrf52",
+  "version": "1.107.0-dev",
+  "description": "Arduino Wiring-based Framework for Nordic Semiconductor nRF52 BLE SoC",
+  "keywords": [
+    "framework",
+    "arduino",
+    "nrf52"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/stealth30110/Adafruit_nRF52_Arduino"
+  },
+  "homepage": "https://github.com/stealth30110/Adafruit_nRF52_Arduino",
+  "license": "LGPL-2.1-or-later",
+  "system": [
+    "*"
+  ]
+}

--- a/tools/build-platformio-package.sh
+++ b/tools/build-platformio-package.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PACKAGE_NAME="framework-arduinoadafruitnrf52"
+REPO_URL="https://github.com/stealth30110/Adafruit_nRF52_Arduino"
+
+usage() {
+  echo "Usage: $0 <version> [output-dir]" >&2
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+VERSION="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OUTPUT_DIR="${2:-${REPO_ROOT}/dist}"
+STAGE_ROOT="$(mktemp -d)"
+PACKAGE_ROOT="${STAGE_ROOT}/${PACKAGE_NAME}"
+ARCHIVE_PATH="${OUTPUT_DIR}/${PACKAGE_NAME}.tar.bz2"
+
+cleanup() {
+  rm -rf "${STAGE_ROOT}"
+}
+
+trap cleanup EXIT
+
+mkdir -p "${OUTPUT_DIR}" "${PACKAGE_ROOT}"
+
+# Copy only the files that are part of the framework package.
+PACKAGE_CONTENTS=(
+  boards.txt
+  bootloader
+  changelog.md
+  CODE_OF_CONDUCT.md
+  cores
+  keywords.txt
+  libraries
+  LICENSE
+  platform.txt
+  programmers.txt
+  README.md
+  scripts
+  tools
+  variants
+)
+
+for entry in "${PACKAGE_CONTENTS[@]}"; do
+  if [[ -e "${REPO_ROOT}/${entry}" ]]; then
+    cp -a "${REPO_ROOT}/${entry}" "${PACKAGE_ROOT}/"
+  fi
+done
+
+cat > "${PACKAGE_ROOT}/package.json" <<EOF
+{
+  "name": "${PACKAGE_NAME}",
+  "version": "${VERSION}",
+  "description": "Arduino Wiring-based Framework for Nordic Semiconductor nRF52 BLE SoC",
+  "keywords": [
+    "framework",
+    "arduino",
+    "nrf52"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "${REPO_URL}"
+  },
+  "homepage": "${REPO_URL}",
+  "license": "LGPL-2.1-or-later",
+  "system": [
+    "*"
+  ]
+}
+EOF
+
+rm -f "${ARCHIVE_PATH}"
+tar -cjf "${ARCHIVE_PATH}" -C "${STAGE_ROOT}" "${PACKAGE_NAME}"
+
+echo "Created ${ARCHIVE_PATH}"

--- a/tools/compute-platformio-package-version.sh
+++ b/tools/compute-platformio-package-version.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 <base-version> [run-number]" >&2
+}
+
+if [[ $# -lt 1 || $# -gt 2 ]]; then
+  usage
+  exit 1
+fi
+
+BASE_VERSION="$1"
+RUN_NUMBER="${2:-${GITHUB_RUN_NUMBER:-0}}"
+
+if [[ ! "${BASE_VERSION}" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "Base version must look like MAJOR.MINOR, got: ${BASE_VERSION}" >&2
+  exit 1
+fi
+
+if [[ ! "${RUN_NUMBER}" =~ ^[0-9]+$ ]]; then
+  echo "Run number must be numeric, got: ${RUN_NUMBER}" >&2
+  exit 1
+fi
+
+echo "${BASE_VERSION}.${RUN_NUMBER}"

--- a/variants/Seeed_XIAO_nRF52840_Sense/variant.cpp
+++ b/variants/Seeed_XIAO_nRF52840_Sense/variant.cpp
@@ -1,0 +1,66 @@
+#include "variant.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+#include "nrf.h"
+
+const uint32_t g_ADigitalPinMap[] =
+{
+     2, // D0  is P0.02 (A0)
+     3, // D1  is P0.03 (A1)
+    28, // D2  is P0.28 (A2)
+    29, // D3  is P0.29 (A3)
+     4, // D4  is P0.04 (A4, SDA)
+     5, // D5  is P0.05 (A5, SCL)
+    43, // D6  is P1.11 (TX)
+    44, // D7  is P1.12 (RX)
+    45, // D8  is P1.13 (SCK)
+    46, // D9  is P1.14 (MISO)
+    47, // D10 is P1.15 (MOSI)
+
+    26, // D11 is P0.26 (LED RED)
+     6, // D12 is P0.06 (LED BLUE)
+    30, // D13 is P0.30 (LED GREEN)
+    14, // D14 is P0.14 (READ_BAT)
+
+    40, // D15 is P1.08 (6D_PWR)
+    27, // D16 is P0.27 (6D_I2C_SCL)
+     7, // D17 is P0.07 (6D_I2C_SDA)
+    11, // D18 is P0.11 (6D_INT1)
+
+    42, // D19 is P1.10 (MIC_PWR)
+    32, // D20 is P1.00 (PDM_CLK)
+    16, // D21 is P0.16 (PDM_DATA)
+
+    13, // D22 is P0.13 (HICHG)
+    17, // D23 is P0.17 (~CHG)
+
+    21, // D24 is P0.21 (QSPI_SCK)
+    25, // D25 is P0.25 (QSPI_CSN)
+    20, // D26 is P0.20 (QSPI_SIO_0 DI)
+    24, // D27 is P0.24 (QSPI_SIO_1 DO)
+    22, // D28 is P0.22 (QSPI_SIO_2 WP)
+    23, // D29 is P0.23 (QSPI_SIO_3 HOLD)
+
+     9, // D30 is P0.09 (NFC1)
+    10, // D31 is P0.10 (NFC2)
+
+    31, // D32 is P0.31 (VBAT)
+};
+
+void initVariant()
+{
+    pinMode(VBAT_ENABLE, OUTPUT);
+    digitalWrite(VBAT_ENABLE, HIGH);
+
+    pinMode(PIN_CHARGING_CURRENT, INPUT);
+
+    pinMode(PIN_QSPI_CS, OUTPUT);
+    digitalWrite(PIN_QSPI_CS, HIGH);
+
+    pinMode(LED_RED, OUTPUT);
+    digitalWrite(LED_RED, HIGH);
+    pinMode(LED_GREEN, OUTPUT);
+    digitalWrite(LED_GREEN, HIGH);
+    pinMode(LED_BLUE, OUTPUT);
+    digitalWrite(LED_BLUE, HIGH);
+}

--- a/variants/Seeed_XIAO_nRF52840_Sense/variant.h
+++ b/variants/Seeed_XIAO_nRF52840_Sense/variant.h
@@ -1,0 +1,134 @@
+#ifndef _SEEED_XIAO_NRF52840_SENSE_H_
+#define _SEEED_XIAO_NRF52840_SENSE_H_
+
+#define TARGET_SEEED_XIAO_NRF52840_SENSE
+
+/** Master clock frequency */
+#define VARIANT_MCK       (64000000ul)
+
+#define USE_LFXO
+//#define USE_LFRC
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define PINS_COUNT              (33)
+#define NUM_DIGITAL_PINS        (33)
+#define NUM_ANALOG_INPUTS       (8)
+#define NUM_ANALOG_OUTPUTS      (0)
+
+// LEDs
+#define PIN_LED                 (LED_RED)
+#define LED_PWR                 (PINS_COUNT)
+#define PIN_NEOPIXEL            (PINS_COUNT)
+#define NEOPIXEL_NUM            (0)
+
+#define LED_BUILTIN             (PIN_LED)
+
+#define LED_RED                 (11)
+#define LED_GREEN               (13)
+#define LED_BLUE                (12)
+
+#define LED_STATE_ON            (1)
+
+// Buttons
+#define PIN_BUTTON1             (PINS_COUNT)
+
+// Digital pins
+static const uint8_t D0  = 0;
+static const uint8_t D1  = 1;
+static const uint8_t D2  = 2;
+static const uint8_t D3  = 3;
+static const uint8_t D4  = 4;
+static const uint8_t D5  = 5;
+static const uint8_t D6  = 6;
+static const uint8_t D7  = 7;
+static const uint8_t D8  = 8;
+static const uint8_t D9  = 9;
+static const uint8_t D10 = 10;
+
+#define VBAT_ENABLE             (14)
+#define PIN_CHARGING_CURRENT    (22)
+
+// Analog pins
+#define PIN_A0                  (0)
+#define PIN_A1                  (1)
+#define PIN_A2                  (2)
+#define PIN_A3                  (3)
+#define PIN_A4                  (4)
+#define PIN_A5                  (5)
+#define PIN_VBAT                (32)
+
+static const uint8_t A0 = PIN_A0;
+static const uint8_t A1 = PIN_A1;
+static const uint8_t A2 = PIN_A2;
+static const uint8_t A3 = PIN_A3;
+static const uint8_t A4 = PIN_A4;
+static const uint8_t A5 = PIN_A5;
+
+#define ADC_RESOLUTION          (12)
+
+// Other pins
+#define PIN_NFC1                (30)
+#define PIN_NFC2                (31)
+
+// Serial interfaces
+#define PIN_SERIAL1_RX          (7)
+#define PIN_SERIAL1_TX          (6)
+
+// SPI interfaces
+#define SPI_INTERFACES_COUNT    (2)
+
+#define PIN_SPI_MISO            (9)
+#define PIN_SPI_MOSI            (10)
+#define PIN_SPI_SCK             (8)
+
+static const uint8_t SS   = 7;
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK  = PIN_SPI_SCK;
+
+#define PIN_SPI1_MISO           (25)
+#define PIN_SPI1_MOSI           (26)
+#define PIN_SPI1_SCK            (29)
+
+// Wire interfaces
+#define WIRE_INTERFACES_COUNT   (2)
+
+#define PIN_WIRE_SDA            (4)
+#define PIN_WIRE_SCL            (5)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+#define PIN_WIRE1_SDA           (17)
+#define PIN_WIRE1_SCL           (16)
+#define PIN_LSM6DS3TR_C_POWER   (15)
+#define PIN_LSM6DS3TR_C_INT1    (18)
+
+// PDM interface
+#define PIN_PDM_PWR             (19)
+#define PIN_PDM_CLK             (20)
+#define PIN_PDM_DIN             (21)
+
+// QSPI pins
+#define PIN_QSPI_SCK            (24)
+#define PIN_QSPI_CS             (25)
+#define PIN_QSPI_IO0            (26)
+#define PIN_QSPI_IO1            (27)
+#define PIN_QSPI_IO2            (28)
+#define PIN_QSPI_IO3            (29)
+
+// On-board QSPI flash
+#define EXTERNAL_FLASH_DEVICES  (P25Q16H)
+#define EXTERNAL_FLASH_USE_QSPI
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
`BLEConnection::getHvnPacket()` always blocks up to `BLE_GENERIC_TIMEOUT` (100ms) waiting for a free HVN TX credit. If the connection is torn down while a caller is parked in that wait, the disconnect handler (`bluefruit.cpp`, `BLE_GAP_EVT_DISCONNECTED`) deletes the `BLEConnection` — and its _hvn_sem — out from under the still-blocked task. Deleting a FreeRTOS semaphore a task is blocked on is undefined behavior; on hardware this reproduces as a permanent hang.

Adds an optional `timeout_ms`/`hvn_timeout_ms` parameter to `BLEConnection::getHvnPacket()` and `BLECharacteristic::notify(conn_hdl, data, len, ...)`, defaulting to the existing `BLE_GENERIC_TIMEOUT` — every current call site is unaffected. A caller that wants to avoid the block entirely (and the race it enables) can now pass 0 for a non-blocking credit check.

Consumed by stealth30110/startDownFw#38 — see that PR's description (and docs `BLESinkWriteBug.md` in that repo) for the full investigation and hardware repro.